### PR TITLE
added diff feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
@@ -372,9 +372,9 @@ checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -390,9 +390,9 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -451,15 +451,15 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -557,41 +557,41 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -612,20 +612,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -737,7 +737,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
 ]
@@ -765,12 +764,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -792,9 +791,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -808,10 +807,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -830,15 +831,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -956,15 +957,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1013,21 +1014,15 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "powerfmt"
@@ -1076,6 +1071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,15 +1110,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1152,9 +1153,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1280,9 +1281,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1336,7 +1343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1607,9 +1614,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -1649,11 +1656,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1662,14 +1669,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1680,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1690,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1703,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -1761,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -1776,6 +1783,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1874,7 +1887,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hmac",
  "indexmap",
  "lzma-rust2",
@@ -1891,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ CLI flags (e.g. `--port`) take precedence over environment variables.
 3. **Timeline** — Each log file is rendered as a timeline table with line numbers, timestamps, log levels, and messages. A referenced actions summary table appears when action refs are detected (owner/repo, optional path, and version/ref). Toggle debug lines and group markers on/off. Click **epoch** next to any timestamp to copy the Unix epoch (ms) to clipboard. Click the **#** column header to reverse row order (ascending/descending).
 4. **Tips** — If any troubleshooting tips match the log, a collapsible "tips detected" banner appears above the timeline. Matched lines are marked with emoji indicators in the 💡 column. Toggle individual tips on/off via checkboxes; tips without matched lines are marked as banner-only and still toggle their banner state.
 5. **Clean up** — Use the **Delete All Extracted Files** button on the home page to remove all locally stored data. The current storage path is displayed above the button.
-6. **Light/Dark modes** — Toggle light/dark mode with the button in the header. Your preference is saved in `localStorage`.
+6. **Compare** — Use the **Compare two analyses** link on the home page (or visit `/compare` directly) to diff two extracted archives side by side. Pick two existing analyses from dropdowns, upload a fresh pair of ZIPs, or mix the two in one form. The report covers runner type, runner version, requested labels, self-hosted identity (runner name/group/machine), runner image (hosted), Azure region (hosted), diagnostic-logs-enabled, action and reusable-workflow references, and per-step durations. Enable **Fuzzy step matching** to pair steps across reruns whose normalized names match even when their leading numbers differ.
+7. **Light/Dark modes** — Toggle light/dark mode with the button in the header. Your preference is saved in `localStorage`.
 
 The analysis ID in the URL is always the ZIP filename (e.g. uploading `1234567890.zip` → `/analysis/1234567890`).
 
@@ -98,17 +99,22 @@ src/
     mod.rs           # Model module declarations
     log_parser.rs    # Parse workflow logs and runner diagnostic logs
     tips.rs          # TOML-based troubleshooting tips loader & evaluator
+    compare.rs       # Summarize one extracted archive (runner, image, region, actions, step durations)
+    diff.rs          # Pair two ArchiveSummary values into a ComparisonReport
   routes/
     mod.rs           # Route module declarations
     home.rs          # GET / — home page; POST /delete-all — clear files
     upload.rs        # POST /upload — ZIP upload + extraction
     analysis.rs      # GET /analysis/:id — overview; GET /analysis/:id/*logfile — timeline
+    compare.rs       # GET /compare — form; POST /compare/upload — pair upload; GET /compare/:a/:b — diff view
     settings.rs      # GET /settings — tip admin; POST /settings/tips — save tip; POST /settings/tips/delete — delete tip
 templates/
   base.html          # Shared HTML layout
   home.html          # Home page template
   analysis.html      # Analysis overview (file groups, tooltips)
   logfile.html       # Log file timeline table
+  compare.html       # Compare form (pick two analyses or upload a pair)
+  compare_result.html # Compare result (side-by-side diff)
   error.html         # Error page template
 static/
   style.css          # Stylesheet
@@ -148,6 +154,9 @@ Example tip files: `error_lines.toml`, `job_timeout_risk.toml`, `large_time_gap.
 | GET    | `/analysis/:id`             | Analysis overview — grouped file listing   |
 | GET    | `/analysis/:id/*logfile`    | Timeline view of a specific log file       |
 | POST   | `/delete-all`               | Delete all extracted files, redirect to `/`|
+| GET    | `/compare`                  | Compare form — pick two analyses or upload a pair |
+| POST   | `/compare/upload`           | Resolve/upload the pair, redirect to compare view |
+| GET    | `/compare/:a_id/:b_id`      | Side-by-side comparison view (`?fuzzy=1` opt-in)  |
 | GET    | `/settings`                 | Tip admin — list, add, edit, delete tips   |
 | POST   | `/settings/tips`            | Save (create or update) a tip              |
 | POST   | `/settings/tips/delete`     | Delete a tip by source ID                  |

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,18 @@ async fn main() -> anyhow::Result<()> {
             "/analysis/{id}/{*logfile}",
             axum::routing::get(routes::analysis::logfile),
         )
+        .route(
+            "/compare",
+            axum::routing::get(routes::compare::compare_form),
+        )
+        .route(
+            "/compare/upload",
+            axum::routing::post(routes::compare::compare_upload),
+        )
+        .route(
+            "/compare/{a_id}/{b_id}",
+            axum::routing::get(routes::compare::compare_view),
+        )
         .nest_service("/static", ServeDir::new("static"))
         .with_state(shared_config);
 

--- a/src/models/compare.rs
+++ b/src/models/compare.rs
@@ -1,0 +1,693 @@
+//! Archive summarization for the compare view.
+//!
+//! Walks an extracted analysis directory and builds an `ArchiveSummary`
+//! containing the structured signals used by the diff:
+//!   - runner type classification (GitHub-hosted vs self-hosted vs unknown)
+//!   - runner identity (version, name, group, machine, requested labels)
+//!   - runner image (image name + version, hosted only)
+//!   - Azure region (hosted only)
+//!   - referenced GitHub Actions
+//!   - per-step durations
+
+use std::fs;
+use std::path::Path;
+
+use crate::models::log_parser::{self, ActionReference, LogEntry};
+
+/// Runner image block contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerImage {
+    pub image: String,
+    pub version: String,
+}
+
+/// Coarse classification of how the job's runner was provisioned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerType {
+    /// `Hosted Compute Agent` line was present in the Runner Image Provisioner block.
+    GitHubHosted,
+    /// Self-hosted markers (`Runner name:` / `Machine name:`) present, no Provisioner block.
+    SelfHosted,
+    /// Could not classify — neither marker found (older log formats or unusual environments).
+    Unknown,
+}
+
+impl RunnerType {
+    pub fn label(self) -> &'static str {
+        match self {
+            RunnerType::GitHubHosted => "GitHub-hosted",
+            RunnerType::SelfHosted => "Self-hosted",
+            RunnerType::Unknown => "Unknown",
+        }
+    }
+}
+
+/// Identity fields emitted only by self-hosted runners (top of `1_Set up job.txt`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelfHostedIdentity {
+    pub runner_name: Option<String>,
+    pub runner_group: Option<String>,
+    pub machine_name: Option<String>,
+}
+
+impl SelfHostedIdentity {
+    fn is_empty(&self) -> bool {
+        self.runner_name.is_none() && self.runner_group.is_none() && self.machine_name.is_none()
+    }
+}
+
+/// One step's timing signature, used for duration comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepSummary {
+    /// Job folder name (e.g. `hello-world`).
+    pub job_folder: String,
+    /// Step file name (e.g. `3_Run a one-line script.txt`).
+    pub step_file: String,
+    /// Normalized step name for fuzzy matching (digit prefix and `.txt` stripped, lowercased).
+    pub normalized_name: String,
+    /// First timestamped epoch (ms) seen in the step log.
+    pub first_epoch_ms: Option<i64>,
+    /// Last timestamped epoch (ms) seen in the step log.
+    pub last_epoch_ms: Option<i64>,
+    /// Computed duration in ms (last minus first), if both timestamps were found.
+    pub duration_ms: Option<i64>,
+}
+
+/// Summary of one extracted analysis archive.
+#[derive(Debug, Clone)]
+pub struct ArchiveSummary {
+    pub analysis_id: String,
+    /// Coarse classification — GitHub-hosted, self-hosted, or unknown.
+    pub runner_type: RunnerType,
+    /// Runner application version (e.g. `2.334.0`) from `Current runner version: '...'`.
+    pub runner_version: Option<String>,
+    /// Requested job labels from `system.txt` (e.g. `ubuntu-latest`, `self-hosted`).
+    pub requested_labels: Option<String>,
+    /// Self-hosted identity fields (only populated when `runner_type == SelfHosted`).
+    pub self_hosted_identity: Option<SelfHostedIdentity>,
+    pub runner_image: Option<RunnerImage>,
+    pub azure_region: Option<String>,
+    /// Deduplicated action references aggregated across all step logs.
+    pub action_refs: Vec<ActionReference>,
+    /// Whether `runner-diagnostic-logs/` is present in this archive.
+    pub diagnostic_logs_enabled: bool,
+    pub steps: Vec<StepSummary>,
+}
+
+/// Walk `analysis_dir` and build a summary.
+///
+/// `analysis_dir` should be the canonicalized directory for one extracted
+/// upload (e.g. `data/uploads/<id>`). Errors reading individual files are
+/// silently skipped — partial summaries are better than failing the whole
+/// compare view.
+pub fn summarize_archive(analysis_id: &str, analysis_dir: &Path) -> ArchiveSummary {
+    let mut runner_type_indicator: Option<String> = None;
+    let mut runner_image: Option<RunnerImage> = None;
+    let mut azure_region: Option<String> = None;
+    let mut runner_version: Option<String> = None;
+    let mut self_hosted_identity_raw: Option<SelfHostedIdentity> = None;
+    let mut requested_labels: Option<String> = None;
+    let mut all_action_refs: Vec<ActionReference> = Vec::new();
+    let mut steps: Vec<StepSummary> = Vec::new();
+    let mut diagnostic_logs_enabled = false;
+
+    // Iterate top-level entries; each subdirectory is treated as a job folder.
+    let Ok(entries) = fs::read_dir(analysis_dir) else {
+        return ArchiveSummary {
+            analysis_id: analysis_id.to_string(),
+            runner_type: RunnerType::Unknown,
+            runner_version,
+            requested_labels,
+            self_hosted_identity: None,
+            runner_image,
+            azure_region,
+            action_refs: all_action_refs,
+            diagnostic_logs_enabled,
+            steps,
+        };
+    };
+
+    for top in entries.flatten() {
+        let top_path = top.path();
+        let top_name = top_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        if top_path.is_dir() {
+            if top_name == "runner-diagnostic-logs" {
+                diagnostic_logs_enabled = true;
+                continue;
+            }
+
+            // Job folder — iterate step files inside it.
+            let Ok(inner) = fs::read_dir(&top_path) else {
+                continue;
+            };
+
+            for step_entry in inner.flatten() {
+                let step_path = step_entry.path();
+                if !step_path.is_file() {
+                    continue;
+                }
+                let step_file = step_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !step_file.ends_with(".txt") {
+                    continue;
+                }
+
+                let Ok(content) = fs::read_to_string(&step_path) else {
+                    continue;
+                };
+                let parsed = log_parser::parse_workflow_log(&content);
+
+                // Aggregate signals from the "Set up job" step file.
+                // The runner image / provisioner blocks live there.
+                if runner_type_indicator.is_none() {
+                    runner_type_indicator = extract_runner_type(&parsed);
+                }
+                if runner_image.is_none() {
+                    runner_image = extract_runner_image(&parsed);
+                }
+                if azure_region.is_none() {
+                    azure_region = extract_azure_region(&parsed);
+                }
+                if runner_version.is_none() {
+                    runner_version = extract_runner_version(&parsed);
+                }
+                if self_hosted_identity_raw.is_none() {
+                    self_hosted_identity_raw = extract_self_hosted_identity(&parsed);
+                }
+                if requested_labels.is_none() && step_file == "system.txt" {
+                    requested_labels = extract_requested_labels(&parsed);
+                }
+
+                // Extract action refs from this step log and dedupe later.
+                let refs = log_parser::extract_action_references(&parsed);
+                all_action_refs.extend(refs);
+
+                // Compute step duration from first/last timestamp.
+                let first_epoch_ms = parsed.iter().find_map(|e| e.epoch_millis);
+                let last_epoch_ms = parsed.iter().rev().find_map(|e| e.epoch_millis);
+                let duration_ms = match (first_epoch_ms, last_epoch_ms) {
+                    (Some(a), Some(b)) if b >= a => Some(b - a),
+                    _ => None,
+                };
+
+                steps.push(StepSummary {
+                    job_folder: top_name.clone(),
+                    step_file: step_file.clone(),
+                    normalized_name: normalize_step_name(&step_file),
+                    first_epoch_ms,
+                    last_epoch_ms,
+                    duration_ms,
+                });
+            }
+        }
+    }
+
+    // Classify runner type.
+    let runner_type = if runner_type_indicator.is_some() {
+        RunnerType::GitHubHosted
+    } else if self_hosted_identity_raw
+        .as_ref()
+        .is_some_and(|i| !i.is_empty())
+    {
+        RunnerType::SelfHosted
+    } else {
+        RunnerType::Unknown
+    };
+    // Only surface the self-hosted identity when we classified as self-hosted.
+    let self_hosted_identity = match runner_type {
+        RunnerType::SelfHosted => self_hosted_identity_raw,
+        _ => None,
+    };
+
+    // Dedupe action refs by (owner, repo, path, reference), keeping earliest line.
+    all_action_refs.sort_by(|a, b| {
+        (
+            a.owner.clone(),
+            a.repo.clone(),
+            a.path.clone(),
+            a.reference.clone(),
+            a.first_line,
+        )
+            .cmp(&(
+                b.owner.clone(),
+                b.repo.clone(),
+                b.path.clone(),
+                b.reference.clone(),
+                b.first_line,
+            ))
+    });
+    all_action_refs.dedup_by(|a, b| {
+        a.owner == b.owner && a.repo == b.repo && a.path == b.path && a.reference == b.reference
+    });
+
+    // Stable ordering for steps: job folder, then step file.
+    steps.sort_by(|a, b| {
+        a.job_folder
+            .cmp(&b.job_folder)
+            .then_with(|| a.step_file.cmp(&b.step_file))
+    });
+
+    ArchiveSummary {
+        analysis_id: analysis_id.to_string(),
+        runner_type,
+        runner_version,
+        requested_labels,
+        self_hosted_identity,
+        runner_image,
+        azure_region,
+        action_refs: all_action_refs,
+        diagnostic_logs_enabled,
+        steps,
+    }
+}
+
+/// Search for the `Hosted Compute Agent` line inside the
+/// `##[group]Runner Image Provisioner` block. Returns the indicator string
+/// verbatim (currently always "Hosted Compute Agent" if found).
+pub fn extract_runner_type(entries: &[LogEntry]) -> Option<String> {
+    let mut in_provisioner = false;
+    for e in entries {
+        if e.group_start && e.message.trim() == "Runner Image Provisioner" {
+            in_provisioner = true;
+            continue;
+        }
+        if e.group_end {
+            in_provisioner = false;
+            continue;
+        }
+        if in_provisioner && e.message.trim() == "Hosted Compute Agent" {
+            return Some("Hosted Compute Agent".to_string());
+        }
+    }
+    None
+}
+
+/// Parse the `##[group]Runner Image` block for `Image:` and `Version:` lines.
+pub fn extract_runner_image(entries: &[LogEntry]) -> Option<RunnerImage> {
+    let mut in_block = false;
+    let mut image: Option<String> = None;
+    let mut version: Option<String> = None;
+
+    for e in entries {
+        if e.group_start && e.message.trim() == "Runner Image" {
+            in_block = true;
+            continue;
+        }
+        if e.group_end {
+            if in_block {
+                break;
+            }
+            continue;
+        }
+        if !in_block {
+            continue;
+        }
+        if let Some(v) = e.message.strip_prefix("Image:") {
+            image = Some(v.trim().to_string());
+        } else if let Some(v) = e.message.strip_prefix("Version:") {
+            version = Some(v.trim().to_string());
+        }
+    }
+
+    match (image, version) {
+        (Some(image), Some(version)) => Some(RunnerImage { image, version }),
+        _ => None,
+    }
+}
+
+/// Parse the `##[group]Runner Image Provisioner` block for `Azure Region:`.
+pub fn extract_azure_region(entries: &[LogEntry]) -> Option<String> {
+    let mut in_provisioner = false;
+    for e in entries {
+        if e.group_start && e.message.trim() == "Runner Image Provisioner" {
+            in_provisioner = true;
+            continue;
+        }
+        if e.group_end {
+            if in_provisioner {
+                break;
+            }
+            continue;
+        }
+        if !in_provisioner {
+            continue;
+        }
+        if let Some(v) = e.message.strip_prefix("Azure Region:") {
+            let region = v.trim();
+            if !region.is_empty() {
+                return Some(region.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Extract the runner application version from `Current runner version: '...'`.
+/// Present in both hosted and self-hosted setup logs.
+pub fn extract_runner_version(entries: &[LogEntry]) -> Option<String> {
+    for e in entries {
+        if let Some(rest) = e.message.strip_prefix("Current runner version:") {
+            // Strip surrounding whitespace and the wrapping single quotes.
+            let trimmed = rest.trim();
+            let unquoted = trimmed
+                .strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\''))
+                .unwrap_or(trimmed);
+            if !unquoted.is_empty() {
+                return Some(unquoted.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Extract self-hosted identity fields from the top of `1_Set up job.txt`.
+///
+/// Self-hosted runners emit:
+///   Runner name: 'W6L71QWDTQ'
+///   Runner group name: 'Default'
+///   Machine name: 'W6L71QWDTQ'
+///
+/// Returns `None` when none of those lines are present (typical for hosted runners).
+/// Otherwise returns `Some(SelfHostedIdentity { ... })` with whichever fields were found.
+pub fn extract_self_hosted_identity(entries: &[LogEntry]) -> Option<SelfHostedIdentity> {
+    let mut runner_name: Option<String> = None;
+    let mut runner_group: Option<String> = None;
+    let mut machine_name: Option<String> = None;
+
+    for e in entries {
+        // These lines all appear before any `##[group]` header in the setup log,
+        // but checking the whole entry list is cheap and tolerates variations.
+        if let Some(v) = e.message.strip_prefix("Runner name:")
+            && runner_name.is_none()
+        {
+            runner_name = Some(unquote(v.trim()));
+        } else if let Some(v) = e.message.strip_prefix("Runner group name:")
+            && runner_group.is_none()
+        {
+            runner_group = Some(unquote(v.trim()));
+        } else if let Some(v) = e.message.strip_prefix("Machine name:")
+            && machine_name.is_none()
+        {
+            machine_name = Some(unquote(v.trim()));
+        }
+    }
+
+    let identity = SelfHostedIdentity {
+        runner_name,
+        runner_group,
+        machine_name,
+    };
+    if identity.is_empty() {
+        None
+    } else {
+        Some(identity)
+    }
+}
+
+/// Extract the `Requested labels:` value from `system.txt`.
+///
+/// Examples: `ubuntu-latest`, `self-hosted`, `self-hosted, macOS`.
+pub fn extract_requested_labels(entries: &[LogEntry]) -> Option<String> {
+    for e in entries {
+        if let Some(rest) = e.message.strip_prefix("Requested labels:") {
+            let trimmed = rest.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn unquote(s: &str) -> String {
+    s.strip_prefix('\'')
+        .and_then(|t| t.strip_suffix('\''))
+        .unwrap_or(s)
+        .to_string()
+}
+
+/// Normalize a step file name for fuzzy matching across reruns.
+/// Strips a leading `\d+_` prefix, strips a trailing `.txt`, lowercases.
+pub fn normalize_step_name(name: &str) -> String {
+    let stem = name.strip_suffix(".txt").unwrap_or(name);
+    // Strip leading digits + underscore
+    let bytes = stem.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+        idx += 1;
+    }
+    let stripped = if idx > 0 && idx < bytes.len() && bytes[idx] == b'_' {
+        &stem[idx + 1..]
+    } else {
+        stem
+    };
+    stripped.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(content: &str) -> Vec<LogEntry> {
+        log_parser::parse_workflow_log(content)
+    }
+
+    #[test]
+    fn extracts_runner_image_from_synthetic_log() {
+        let content = "\
+2026-04-29T23:55:39.8686412Z ##[group]Runner Image
+2026-04-29T23:55:39.8686888Z Image: ubuntu-24.04
+2026-04-29T23:55:39.8687343Z Version: 20260413.86.1
+2026-04-29T23:55:39.8688249Z Included Software: https://example.com
+2026-04-29T23:55:39.8690476Z ##[endgroup]
+";
+        let entries = parse(content);
+        let image = extract_runner_image(&entries).expect("should detect runner image");
+        assert_eq!(image.image, "ubuntu-24.04");
+        assert_eq!(image.version, "20260413.86.1");
+    }
+
+    #[test]
+    fn extracts_runner_image_returns_none_when_block_absent() {
+        let entries = parse("2026-04-29T23:55:39.8686412Z hello\n");
+        assert!(extract_runner_image(&entries).is_none());
+    }
+
+    #[test]
+    fn detects_hosted_compute_agent() {
+        let content = "\
+2026-04-29T23:55:39.8678146Z ##[group]Runner Image Provisioner
+2026-04-29T23:55:39.8678959Z Hosted Compute Agent
+2026-04-29T23:55:39.8679464Z Version: 20260213.493
+2026-04-29T23:55:39.8682228Z Azure Region: westcentralus
+2026-04-29T23:55:39.8682766Z ##[endgroup]
+";
+        let entries = parse(content);
+        assert_eq!(
+            extract_runner_type(&entries).as_deref(),
+            Some("Hosted Compute Agent")
+        );
+    }
+
+    #[test]
+    fn detects_hosted_compute_agent_negative() {
+        // The string appears outside the provisioner block; should not match.
+        let content = "2026-04-29T23:55:39.0Z Hosted Compute Agent\n";
+        let entries = parse(content);
+        assert!(extract_runner_type(&entries).is_none());
+    }
+
+    #[test]
+    fn extracts_azure_region_positive() {
+        let content = "\
+2026-04-29T23:55:39.8678146Z ##[group]Runner Image Provisioner
+2026-04-29T23:55:39.8678959Z Hosted Compute Agent
+2026-04-29T23:55:39.8682228Z Azure Region: westcentralus
+2026-04-29T23:55:39.8682766Z ##[endgroup]
+";
+        let entries = parse(content);
+        assert_eq!(
+            extract_azure_region(&entries).as_deref(),
+            Some("westcentralus")
+        );
+    }
+
+    #[test]
+    fn extracts_azure_region_returns_none_when_block_absent() {
+        // No provisioner block at all (e.g. self-hosted runner).
+        let content = "2026-04-29T23:55:39.0Z Current runner version: '2.334.0'\n";
+        let entries = parse(content);
+        assert!(extract_azure_region(&entries).is_none());
+    }
+
+    #[test]
+    fn extracts_azure_region_returns_none_when_line_absent() {
+        // Provisioner block exists but no Azure Region line.
+        let content = "\
+2026-04-29T23:55:39.0Z ##[group]Runner Image Provisioner
+2026-04-29T23:55:39.0Z Hosted Compute Agent
+2026-04-29T23:55:39.0Z ##[endgroup]
+";
+        let entries = parse(content);
+        assert!(extract_azure_region(&entries).is_none());
+    }
+
+    #[test]
+    fn computes_step_duration_from_first_last_timestamps() {
+        // Build a tiny archive on disk and summarize it.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let analysis_dir = tmp.path().join("xyz");
+        let job_dir = analysis_dir.join("hello-world");
+        fs::create_dir_all(&job_dir).expect("mkdir");
+        // Two-line step file: 1 second apart.
+        let step = "\
+2026-04-29T23:55:41.0000000Z First line\n\
+2026-04-29T23:55:42.0000000Z Last line\n";
+        fs::write(job_dir.join("3_Run a one-line script.txt"), step).expect("write");
+
+        let summary = summarize_archive("xyz", &analysis_dir);
+        assert_eq!(summary.steps.len(), 1);
+        let s = &summary.steps[0];
+        assert_eq!(s.job_folder, "hello-world");
+        assert_eq!(s.step_file, "3_Run a one-line script.txt");
+        assert_eq!(s.duration_ms, Some(1000));
+    }
+
+    #[test]
+    fn summarize_detects_diagnostic_logs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let analysis_dir = tmp.path().join("with-diag");
+        fs::create_dir_all(analysis_dir.join("runner-diagnostic-logs")).expect("mkdir");
+        let summary = summarize_archive("with-diag", &analysis_dir);
+        assert!(summary.diagnostic_logs_enabled);
+    }
+
+    #[test]
+    fn normalize_step_name_strips_prefix_and_suffix() {
+        assert_eq!(
+            normalize_step_name("3_Run a one-line script.txt"),
+            "run a one-line script"
+        );
+        assert_eq!(normalize_step_name("12_Set up job.txt"), "set up job");
+        // No digit prefix
+        assert_eq!(normalize_step_name("system.txt"), "system");
+        // Underscore not preceded by digits stays
+        assert_eq!(normalize_step_name("my_step.txt"), "my_step");
+    }
+
+    #[test]
+    fn extracts_runner_version() {
+        let content = "2026-04-29T23:55:39.0Z Current runner version: '2.334.0'\n";
+        let entries = parse(content);
+        assert_eq!(extract_runner_version(&entries).as_deref(), Some("2.334.0"));
+    }
+
+    #[test]
+    fn extracts_runner_version_returns_none_when_absent() {
+        let entries = parse("2026-04-29T23:55:39.0Z hello\n");
+        assert!(extract_runner_version(&entries).is_none());
+    }
+
+    #[test]
+    fn extracts_self_hosted_identity_from_synthetic_log() {
+        let content = "\
+2026-04-30T00:42:29.0472190Z Current runner version: '2.334.0'
+2026-04-30T00:42:29.0481180Z Runner name: 'W6L71QWDTQ'
+2026-04-30T00:42:29.0481650Z Runner group name: 'Default'
+2026-04-30T00:42:29.0482290Z Machine name: 'W6L71QWDTQ'
+";
+        let entries = parse(content);
+        let identity = extract_self_hosted_identity(&entries).expect("identity should be detected");
+        assert_eq!(identity.runner_name.as_deref(), Some("W6L71QWDTQ"));
+        assert_eq!(identity.runner_group.as_deref(), Some("Default"));
+        assert_eq!(identity.machine_name.as_deref(), Some("W6L71QWDTQ"));
+    }
+
+    #[test]
+    fn extracts_self_hosted_identity_returns_none_for_hosted_log() {
+        // A hosted setup log has no `Runner name:` or `Machine name:` lines.
+        let content = "\
+2026-04-29T23:55:39.0Z Current runner version: '2.334.0'
+2026-04-29T23:55:39.0Z ##[group]Runner Image Provisioner
+2026-04-29T23:55:39.0Z Hosted Compute Agent
+2026-04-29T23:55:39.0Z ##[endgroup]
+";
+        let entries = parse(content);
+        assert!(extract_self_hosted_identity(&entries).is_none());
+    }
+
+    #[test]
+    fn extracts_requested_labels() {
+        let content = "2026-04-29T23:55:37.4950000Z Requested labels: ubuntu-latest\n";
+        let entries = parse(content);
+        assert_eq!(
+            extract_requested_labels(&entries).as_deref(),
+            Some("ubuntu-latest")
+        );
+    }
+
+    #[test]
+    fn summarize_classifies_self_hosted_runner() {
+        // Build a tiny archive that mirrors the macOS self-hosted sample.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let analysis_dir = tmp.path().join("sh");
+        let job_dir = analysis_dir.join("hello-world");
+        fs::create_dir_all(&job_dir).expect("mkdir");
+        let setup = "\
+2026-04-30T00:42:29.0472190Z Current runner version: '2.334.0'
+2026-04-30T00:42:29.0481180Z Runner name: 'W6L71QWDTQ'
+2026-04-30T00:42:29.0481650Z Runner group name: 'Default'
+2026-04-30T00:42:29.0482290Z Machine name: 'W6L71QWDTQ'
+";
+        fs::write(job_dir.join("1_Set up job.txt"), setup).expect("write");
+        let system = "2026-04-30T00:42:26.3560000Z Requested labels: self-hosted\n";
+        fs::write(job_dir.join("system.txt"), system).expect("write");
+
+        let summary = summarize_archive("sh", &analysis_dir);
+        assert_eq!(summary.runner_type, RunnerType::SelfHosted);
+        assert_eq!(summary.runner_version.as_deref(), Some("2.334.0"));
+        assert_eq!(summary.requested_labels.as_deref(), Some("self-hosted"));
+        let identity = summary
+            .self_hosted_identity
+            .expect("self-hosted identity present");
+        assert_eq!(identity.runner_name.as_deref(), Some("W6L71QWDTQ"));
+        assert_eq!(identity.machine_name.as_deref(), Some("W6L71QWDTQ"));
+        assert!(summary.runner_image.is_none());
+        assert!(summary.azure_region.is_none());
+    }
+
+    #[test]
+    fn summarize_classifies_github_hosted_runner() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let analysis_dir = tmp.path().join("gh");
+        let job_dir = analysis_dir.join("hello-world");
+        fs::create_dir_all(&job_dir).expect("mkdir");
+        let setup = "\
+2026-04-29T23:55:39.0Z Current runner version: '2.334.0'
+2026-04-29T23:55:39.0Z ##[group]Runner Image Provisioner
+2026-04-29T23:55:39.0Z Hosted Compute Agent
+2026-04-29T23:55:39.0Z Azure Region: westcentralus
+2026-04-29T23:55:39.0Z ##[endgroup]
+2026-04-29T23:55:39.0Z ##[group]Runner Image
+2026-04-29T23:55:39.0Z Image: ubuntu-24.04
+2026-04-29T23:55:39.0Z Version: 20260413.86.1
+2026-04-29T23:55:39.0Z ##[endgroup]
+";
+        fs::write(job_dir.join("1_Set up job.txt"), setup).expect("write");
+
+        let summary = summarize_archive("gh", &analysis_dir);
+        assert_eq!(summary.runner_type, RunnerType::GitHubHosted);
+        assert!(summary.self_hosted_identity.is_none());
+        assert_eq!(summary.azure_region.as_deref(), Some("westcentralus"));
+        assert!(summary.runner_image.is_some());
+    }
+}

--- a/src/models/diff.rs
+++ b/src/models/diff.rs
@@ -1,0 +1,517 @@
+//! Pairing and diffing of two `ArchiveSummary` values.
+
+use std::collections::BTreeMap;
+
+use crate::models::compare::{
+    ArchiveSummary, RunnerImage, RunnerType, SelfHostedIdentity, StepSummary,
+};
+use crate::models::log_parser::ActionReference;
+
+/// A side-by-side comparison of a single optional value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringComparison {
+    pub a: Option<String>,
+    pub b: Option<String>,
+    pub differs: bool,
+}
+
+impl StringComparison {
+    fn new(a: Option<String>, b: Option<String>) -> Self {
+        let differs = a != b;
+        Self { a, b, differs }
+    }
+}
+
+/// A side-by-side comparison of an optional `RunnerImage`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerImageComparison {
+    pub a: Option<RunnerImage>,
+    pub b: Option<RunnerImage>,
+    pub differs: bool,
+}
+
+impl RunnerImageComparison {
+    fn new(a: Option<RunnerImage>, b: Option<RunnerImage>) -> Self {
+        let differs = a != b;
+        Self { a, b, differs }
+    }
+}
+
+/// A boolean side-by-side comparison (e.g. diagnostic-logs-enabled).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoolComparison {
+    pub a: bool,
+    pub b: bool,
+    pub differs: bool,
+}
+
+impl BoolComparison {
+    fn new(a: bool, b: bool) -> Self {
+        Self {
+            a,
+            b,
+            differs: a != b,
+        }
+    }
+}
+
+/// A side-by-side comparison of `RunnerType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunnerTypeComparison {
+    pub a: RunnerType,
+    pub b: RunnerType,
+    pub differs: bool,
+}
+
+impl RunnerTypeComparison {
+    fn new(a: RunnerType, b: RunnerType) -> Self {
+        Self {
+            a,
+            b,
+            differs: a != b,
+        }
+    }
+}
+
+/// A side-by-side comparison of an optional `SelfHostedIdentity`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityComparison {
+    pub a: Option<SelfHostedIdentity>,
+    pub b: Option<SelfHostedIdentity>,
+    pub differs: bool,
+}
+
+impl IdentityComparison {
+    fn new(a: Option<SelfHostedIdentity>, b: Option<SelfHostedIdentity>) -> Self {
+        let differs = a != b;
+        Self { a, b, differs }
+    }
+}
+
+/// A paired action reference present in both archives.
+#[derive(Debug, Clone)]
+pub struct PairedActionRef {
+    pub owner_repo_path: String,
+    pub github_url: String,
+    pub a_reference: String,
+    pub b_reference: String,
+    pub differs: bool,
+}
+
+/// Buckets of action-ref differences between two archives.
+#[derive(Debug, Clone, Default)]
+pub struct ActionRefDiff {
+    pub paired: Vec<PairedActionRef>,
+    pub only_in_a: Vec<ActionReference>,
+    pub only_in_b: Vec<ActionReference>,
+}
+
+/// A paired step (same job folder + step file, or fuzzy match).
+#[derive(Debug, Clone)]
+pub struct PairedStep {
+    pub label: String,
+    pub a_duration_ms: Option<i64>,
+    pub b_duration_ms: Option<i64>,
+    pub delta_ms: Option<i64>,
+}
+
+/// Buckets of step-pairing results.
+#[derive(Debug, Clone, Default)]
+pub struct StepDiff {
+    /// Steps present in both archives. May span multiple job folders.
+    pub paired_by_job: Vec<JobStepGroup>,
+    pub only_in_a: Vec<StepSummary>,
+    pub only_in_b: Vec<StepSummary>,
+}
+
+/// Group of paired steps within one job folder, for table-grouped rendering.
+#[derive(Debug, Clone)]
+pub struct JobStepGroup {
+    pub job_folder: String,
+    pub steps: Vec<PairedStep>,
+}
+
+/// Top-level comparison result handed to the template.
+#[derive(Debug, Clone)]
+pub struct ComparisonReport {
+    pub a_id: String,
+    pub b_id: String,
+    pub fuzzy: bool,
+    pub runner_type: RunnerTypeComparison,
+    pub runner_version: StringComparison,
+    pub requested_labels: StringComparison,
+    pub self_hosted_identity: IdentityComparison,
+    pub runner_image: RunnerImageComparison,
+    pub azure_region: StringComparison,
+    pub diagnostic_logs: BoolComparison,
+    pub action_refs: ActionRefDiff,
+    pub steps: StepDiff,
+}
+
+/// Compute the comparison report between two archive summaries.
+pub fn compare(a: &ArchiveSummary, b: &ArchiveSummary, fuzzy: bool) -> ComparisonReport {
+    ComparisonReport {
+        a_id: a.analysis_id.clone(),
+        b_id: b.analysis_id.clone(),
+        fuzzy,
+        runner_type: RunnerTypeComparison::new(a.runner_type, b.runner_type),
+        runner_version: StringComparison::new(a.runner_version.clone(), b.runner_version.clone()),
+        requested_labels: StringComparison::new(
+            a.requested_labels.clone(),
+            b.requested_labels.clone(),
+        ),
+        self_hosted_identity: IdentityComparison::new(
+            a.self_hosted_identity.clone(),
+            b.self_hosted_identity.clone(),
+        ),
+        runner_image: RunnerImageComparison::new(a.runner_image.clone(), b.runner_image.clone()),
+        azure_region: StringComparison::new(a.azure_region.clone(), b.azure_region.clone()),
+        diagnostic_logs: BoolComparison::new(a.diagnostic_logs_enabled, b.diagnostic_logs_enabled),
+        action_refs: diff_action_refs(&a.action_refs, &b.action_refs),
+        steps: diff_steps(&a.steps, &b.steps, fuzzy),
+    }
+}
+
+fn key_owner_repo_path(r: &ActionReference) -> String {
+    match &r.path {
+        Some(p) => format!("{}/{}{}", r.owner, r.repo, p),
+        None => format!("{}/{}", r.owner, r.repo),
+    }
+}
+
+fn diff_action_refs(a: &[ActionReference], b: &[ActionReference]) -> ActionRefDiff {
+    // Bucket each side by (owner, repo, path). If multiple refs share the same
+    // key on one side, keep the first one (earliest line).
+    let mut a_by_key: BTreeMap<String, ActionReference> = BTreeMap::new();
+    for r in a {
+        a_by_key
+            .entry(key_owner_repo_path(r))
+            .or_insert_with(|| r.clone());
+    }
+    let mut b_by_key: BTreeMap<String, ActionReference> = BTreeMap::new();
+    for r in b {
+        b_by_key
+            .entry(key_owner_repo_path(r))
+            .or_insert_with(|| r.clone());
+    }
+
+    let mut paired: Vec<PairedActionRef> = Vec::new();
+    let mut only_in_a: Vec<ActionReference> = Vec::new();
+    let mut only_in_b: Vec<ActionReference> = Vec::new();
+
+    let mut all_keys: Vec<&String> = a_by_key.keys().chain(b_by_key.keys()).collect();
+    all_keys.sort();
+    all_keys.dedup();
+
+    for key in all_keys {
+        match (a_by_key.get(key), b_by_key.get(key)) {
+            (Some(ra), Some(rb)) => {
+                let differs = ra.reference != rb.reference;
+                paired.push(PairedActionRef {
+                    owner_repo_path: key.clone(),
+                    github_url: ra.github_url(),
+                    a_reference: ra.reference.clone(),
+                    b_reference: rb.reference.clone(),
+                    differs,
+                });
+            }
+            (Some(ra), None) => only_in_a.push(ra.clone()),
+            (None, Some(rb)) => only_in_b.push(rb.clone()),
+            (None, None) => {}
+        }
+    }
+
+    ActionRefDiff {
+        paired,
+        only_in_a,
+        only_in_b,
+    }
+}
+
+fn diff_steps(a: &[StepSummary], b: &[StepSummary], fuzzy: bool) -> StepDiff {
+    // Pair by exact (job_folder, step_file) first.
+    let mut a_used = vec![false; a.len()];
+    let mut b_used = vec![false; b.len()];
+    let mut paired_pairs: Vec<(usize, usize)> = Vec::new();
+
+    for (i, sa) in a.iter().enumerate() {
+        for (j, sb) in b.iter().enumerate() {
+            if !b_used[j] && sa.job_folder == sb.job_folder && sa.step_file == sb.step_file {
+                paired_pairs.push((i, j));
+                a_used[i] = true;
+                b_used[j] = true;
+                break;
+            }
+        }
+    }
+
+    if fuzzy {
+        // Pair leftovers by normalized name across job folders.
+        for i in 0..a.len() {
+            if a_used[i] {
+                continue;
+            }
+            for j in 0..b.len() {
+                if b_used[j] {
+                    continue;
+                }
+                if a[i].normalized_name == b[j].normalized_name {
+                    paired_pairs.push((i, j));
+                    a_used[i] = true;
+                    b_used[j] = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Group paired steps by the A-side job folder.
+    let mut by_job: BTreeMap<String, Vec<PairedStep>> = BTreeMap::new();
+    for (i, j) in &paired_pairs {
+        let sa = &a[*i];
+        let sb = &b[*j];
+        let label = if sa.step_file == sb.step_file {
+            sa.step_file.clone()
+        } else {
+            format!("{} ⇄ {}", sa.step_file, sb.step_file)
+        };
+        let delta_ms = match (sa.duration_ms, sb.duration_ms) {
+            (Some(da), Some(db)) => Some(db - da),
+            _ => None,
+        };
+        by_job
+            .entry(sa.job_folder.clone())
+            .or_default()
+            .push(PairedStep {
+                label,
+                a_duration_ms: sa.duration_ms,
+                b_duration_ms: sb.duration_ms,
+                delta_ms,
+            });
+    }
+
+    let paired_by_job: Vec<JobStepGroup> = by_job
+        .into_iter()
+        .map(|(job_folder, steps)| JobStepGroup { job_folder, steps })
+        .collect();
+
+    let only_in_a: Vec<StepSummary> = a
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !a_used[*i])
+        .map(|(_, s)| s.clone())
+        .collect();
+    let only_in_b: Vec<StepSummary> = b
+        .iter()
+        .enumerate()
+        .filter(|(j, _)| !b_used[*j])
+        .map(|(_, s)| s.clone())
+        .collect();
+
+    StepDiff {
+        paired_by_job,
+        only_in_a,
+        only_in_b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aref(owner: &str, repo: &str, reference: &str) -> ActionReference {
+        ActionReference {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            path: None,
+            reference: reference.to_string(),
+            first_line: 1,
+        }
+    }
+
+    fn step(job: &str, file: &str, dur: Option<i64>) -> StepSummary {
+        StepSummary {
+            job_folder: job.to_string(),
+            step_file: file.to_string(),
+            normalized_name: crate::models::compare::normalize_step_name(file),
+            first_epoch_ms: dur.map(|_| 0),
+            last_epoch_ms: dur,
+            duration_ms: dur,
+        }
+    }
+
+    fn empty_summary(id: &str) -> ArchiveSummary {
+        ArchiveSummary {
+            analysis_id: id.to_string(),
+            runner_type: RunnerType::Unknown,
+            runner_version: None,
+            requested_labels: None,
+            self_hosted_identity: None,
+            runner_image: None,
+            azure_region: None,
+            action_refs: Vec::new(),
+            diagnostic_logs_enabled: false,
+            steps: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn flags_azure_region_difference() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.azure_region = Some("westcentralus".to_string());
+        b.azure_region = Some("eastus".to_string());
+        let report = compare(&a, &b, false);
+        assert!(report.azure_region.differs);
+        assert_eq!(report.azure_region.a.as_deref(), Some("westcentralus"));
+        assert_eq!(report.azure_region.b.as_deref(), Some("eastus"));
+    }
+
+    #[test]
+    fn flags_azure_region_same() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.azure_region = Some("eastus".to_string());
+        b.azure_region = Some("eastus".to_string());
+        let report = compare(&a, &b, false);
+        assert!(!report.azure_region.differs);
+    }
+
+    #[test]
+    fn flags_runner_image_difference() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.runner_image = Some(RunnerImage {
+            image: "ubuntu-24.04".into(),
+            version: "20260101.1".into(),
+        });
+        b.runner_image = Some(RunnerImage {
+            image: "ubuntu-24.04".into(),
+            version: "20260413.86.1".into(),
+        });
+        let report = compare(&a, &b, false);
+        assert!(report.runner_image.differs);
+    }
+
+    #[test]
+    fn flags_runner_type_same() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.runner_type = RunnerType::GitHubHosted;
+        b.runner_type = RunnerType::GitHubHosted;
+        let report = compare(&a, &b, false);
+        assert!(!report.runner_type.differs);
+    }
+
+    #[test]
+    fn flags_runner_type_difference_hosted_vs_self_hosted() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.runner_type = RunnerType::GitHubHosted;
+        b.runner_type = RunnerType::SelfHosted;
+        let report = compare(&a, &b, false);
+        assert!(report.runner_type.differs);
+        assert_eq!(report.runner_type.a, RunnerType::GitHubHosted);
+        assert_eq!(report.runner_type.b, RunnerType::SelfHosted);
+    }
+
+    #[test]
+    fn buckets_action_refs_correctly() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        // Same on both sides
+        a.action_refs.push(aref("actions", "checkout", "v4"));
+        b.action_refs.push(aref("actions", "checkout", "v4"));
+        // Changed reference
+        a.action_refs.push(aref("actions", "setup-node", "v3"));
+        b.action_refs.push(aref("actions", "setup-node", "v4"));
+        // Only in A
+        a.action_refs.push(aref("actions", "cache", "v3"));
+        // Only in B
+        b.action_refs.push(aref("actions", "upload-artifact", "v4"));
+
+        let report = compare(&a, &b, false);
+        let paired = &report.action_refs.paired;
+        assert_eq!(paired.len(), 2);
+
+        let same = paired
+            .iter()
+            .find(|p| p.owner_repo_path == "actions/checkout")
+            .expect("same pair");
+        assert!(!same.differs);
+
+        let changed = paired
+            .iter()
+            .find(|p| p.owner_repo_path == "actions/setup-node")
+            .expect("changed pair");
+        assert!(changed.differs);
+        assert_eq!(changed.a_reference, "v3");
+        assert_eq!(changed.b_reference, "v4");
+
+        assert_eq!(report.action_refs.only_in_a.len(), 1);
+        assert_eq!(report.action_refs.only_in_a[0].repo, "cache");
+        assert_eq!(report.action_refs.only_in_b.len(), 1);
+        assert_eq!(report.action_refs.only_in_b[0].repo, "upload-artifact");
+    }
+
+    #[test]
+    fn pairs_steps_exact() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.steps
+            .push(step("hello-world", "1_Set up job.txt", Some(1000)));
+        a.steps.push(step(
+            "hello-world",
+            "3_Run a one-line script.txt",
+            Some(2000),
+        ));
+        b.steps
+            .push(step("hello-world", "1_Set up job.txt", Some(1500)));
+        // Different prefix → does not pair under exact mode
+        b.steps.push(step(
+            "hello-world",
+            "5_Run a one-line script.txt",
+            Some(2500),
+        ));
+
+        let report = compare(&a, &b, false);
+        assert_eq!(report.steps.paired_by_job.len(), 1);
+        let group = &report.steps.paired_by_job[0];
+        assert_eq!(group.job_folder, "hello-world");
+        assert_eq!(group.steps.len(), 1);
+        assert_eq!(group.steps[0].label, "1_Set up job.txt");
+        assert_eq!(group.steps[0].delta_ms, Some(500));
+        assert_eq!(report.steps.only_in_a.len(), 1);
+        assert_eq!(report.steps.only_in_b.len(), 1);
+    }
+
+    #[test]
+    fn pairs_steps_fuzzy() {
+        let mut a = empty_summary("a");
+        let mut b = empty_summary("b");
+        a.steps.push(step(
+            "hello-world",
+            "3_Run a one-line script.txt",
+            Some(2000),
+        ));
+        // Same normalized name but different prefix → only pairs with fuzzy on
+        b.steps.push(step(
+            "hello-world",
+            "5_Run a one-line script.txt",
+            Some(2500),
+        ));
+
+        let exact = compare(&a, &b, false);
+        assert!(exact.steps.paired_by_job.is_empty());
+        assert_eq!(exact.steps.only_in_a.len(), 1);
+        assert_eq!(exact.steps.only_in_b.len(), 1);
+
+        let fuzzy = compare(&a, &b, true);
+        assert_eq!(fuzzy.steps.paired_by_job.len(), 1);
+        let group = &fuzzy.steps.paired_by_job[0];
+        assert_eq!(group.steps.len(), 1);
+        assert_eq!(group.steps[0].delta_ms, Some(500));
+        assert!(fuzzy.steps.only_in_a.is_empty());
+        assert!(fuzzy.steps.only_in_b.is_empty());
+    }
+}

--- a/src/models/log_parser.rs
+++ b/src/models/log_parser.rs
@@ -94,6 +94,11 @@ impl LogLevel {
 ///
 /// Handles the format: `2025-04-30T00:53:42.8434646Z ##[debug]message`
 pub fn parse_workflow_log(content: &str) -> Vec<LogEntry> {
+    // GitHub Actions log files often start with a UTF-8 BOM (EF BB BF). If
+    // present on line 1, it shifts the timestamp position and prevents the
+    // timestamp + message parser from recognizing the line. Strip it once at
+    // the start of the content so all downstream parsing works uniformly.
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(content);
     content
         .lines()
         .enumerate()
@@ -105,6 +110,7 @@ pub fn parse_workflow_log(content: &str) -> Vec<LogEntry> {
 ///
 /// Handles the format: `[2025-04-30 00:53:40Z INFO HostContext] message`
 pub fn parse_runner_log(content: &str) -> Vec<LogEntry> {
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(content);
     content
         .lines()
         .enumerate()
@@ -118,6 +124,15 @@ pub fn parse_runner_log(content: &str) -> Vec<LogEntry> {
 /// - `actions/checkout@v4`
 /// - `github/codeql-action/init@v3`
 /// - `actions/checkout@08c6903...`
+/// - `octo-org/shared/.github/workflows/build.yml@v1` (reusable workflow)
+///
+/// Skips matches inside `Job defined at:` lines, which point to the workflow
+/// file that defines the current job (metadata about the run itself, not a
+/// dependency the workflow uses). Also skips warning/error/notice entries,
+/// where action refs typically appear inside prose (e.g. deprecation
+/// warnings) and produce false positives like `v4.` from sentence-ending
+/// punctuation. Trailing punctuation on captured refs is trimmed as a
+/// secondary safeguard.
 pub fn extract_action_references(entries: &[LogEntry]) -> Vec<ActionReference> {
     let regex = Regex::new(
         r"(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)(?P<path>/[A-Za-z0-9_.\-/]+)?@(?P<reference>[A-Za-z0-9_.\-/]+)",
@@ -128,11 +143,38 @@ pub fn extract_action_references(entries: &[LogEntry]) -> Vec<ActionReference> {
     let mut references = Vec::new();
 
     for entry in entries {
+        // Skip "Job defined at: <owner/repo/.../workflow.yml@ref>" — that's the
+        // location of the workflow file itself, not an action it calls.
+        if entry.message.starts_with("Job defined at:") {
+            continue;
+        }
+        // Skip warnings/errors/notices: these carry prose that frequently
+        // mentions action refs in a sentence (e.g. "...actions/checkout@v4.
+        // Actions will be forced..."), which leads to bogus captures like
+        // "v4." with trailing punctuation. Real action references appear in
+        // info-level lines such as "Run actions/checkout@v4" and
+        // "Download action repository '...@<ref>'".
+        if matches!(
+            entry.level,
+            LogLevel::Warning | LogLevel::Error | LogLevel::Notice
+        ) {
+            continue;
+        }
         for captures in regex.captures_iter(&entry.message) {
             let owner = captures["owner"].to_string();
             let repo = captures["repo"].to_string();
             let path = captures.name("path").map(|m| m.as_str().to_string());
-            let reference = captures["reference"].to_string();
+            // Strip trailing punctuation that can leak in when the regex
+            // matches inside prose (period, comma, semicolon, colon, closing
+            // brackets/quotes). Real refs never end in these characters.
+            let reference = captures["reference"]
+                .trim_end_matches(|c: char| {
+                    matches!(c, '.' | ',' | ';' | ':' | ')' | ']' | '"' | '\'')
+                })
+                .to_string();
+            if reference.is_empty() {
+                continue;
+            }
 
             let key = (owner.clone(), repo.clone(), path.clone(), reference.clone());
             if !seen.insert(key) {
@@ -370,6 +412,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_workflow_strips_leading_bom() {
+        // GitHub Actions log files often start with a UTF-8 BOM. The parser
+        // must strip it so line 1's timestamp + message parse correctly.
+        let content = "\u{FEFF}2025-04-30T00:53:44.8073929Z Current runner version: '2.334.0'";
+        let entries = parse_workflow_log(content);
+        let e = &entries[0];
+        assert_eq!(e.timestamp.as_deref(), Some("2025-04-30T00:53:44.8073929Z"));
+        assert_eq!(e.message, "Current runner version: '2.334.0'");
+    }
+
+    #[test]
     fn test_parse_runner_log_line() {
         let line = "[2025-04-30 00:53:40Z INFO Listener] Version: 2.323.0";
         let entries = parse_runner_log(line);
@@ -478,5 +531,70 @@ mod tests {
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].owner_repo(), "actions/checkout");
         assert_eq!(refs[0].first_line, 1);
+    }
+
+    #[test]
+    fn test_extract_action_references_skips_job_defined_at() {
+        // The "Job defined at:" line points to the workflow file that defines
+        // the current job, not to a dependency. Filter it out.
+        let entries = parse_workflow_log(
+            "2025-04-30T00:00:00Z Run actions/checkout@v4\n\
+             2025-04-30T00:00:01Z Job defined at: corycalahan/hello-world-workflow/.github/workflows/hello-world.yml@refs/heads/main",
+        );
+
+        let refs = extract_action_references(&entries);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].owner_repo(), "actions/checkout");
+    }
+
+    #[test]
+    fn test_extract_action_references_keeps_reusable_workflows() {
+        // Reusable workflow calls look like `owner/repo/.github/workflows/x.yml@ref`
+        // and should still be captured — they're real dependencies.
+        let entries = parse_workflow_log(
+            "2025-04-30T00:00:00Z Download action repository 'octo-org/shared/.github/workflows/build.yml@v1'",
+        );
+
+        let refs = extract_action_references(&entries);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].owner, "octo-org");
+        assert_eq!(refs[0].repo, "shared");
+        assert_eq!(
+            refs[0].path.as_deref(),
+            Some("/.github/workflows/build.yml")
+        );
+        assert_eq!(refs[0].reference, "v1");
+    }
+
+    #[test]
+    fn test_extract_action_references_skips_warning_prose() {
+        // Real-world case from logs_66805516233/0_hello-world.txt: a
+        // deprecation warning mentions "actions/checkout@v4." with a
+        // sentence-ending period. Without the warning skip, the regex
+        // captured "v4." as a separate reference.
+        let entries = parse_workflow_log(
+            "2026-04-29T23:55:40.4172303Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)\n\
+             2026-04-29T23:55:40.6646400Z ##[group]Run actions/checkout@v4\n\
+             2026-04-29T23:55:41.5016115Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.",
+        );
+
+        let refs = extract_action_references(&entries);
+        assert_eq!(refs.len(), 1, "expected only the legitimate v4 ref");
+        assert_eq!(refs[0].owner_repo(), "actions/checkout");
+        assert_eq!(refs[0].reference, "v4");
+    }
+
+    #[test]
+    fn test_extract_action_references_trims_trailing_punctuation() {
+        // Defense-in-depth: if a non-warning info line ever contains a ref
+        // followed by punctuation, normalize it rather than treating "v4,"
+        // and "v4" as distinct references.
+        let entries = parse_workflow_log(
+            "2025-04-30T00:00:00Z Note: using actions/checkout@v4, then continuing.",
+        );
+
+        let refs = extract_action_references(&entries);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].reference, "v4");
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,4 @@
+pub mod compare;
+pub mod diff;
 pub mod log_parser;
 pub mod tips;

--- a/src/models/tips.rs
+++ b/src/models/tips.rs
@@ -125,6 +125,7 @@ impl TipScope {
 
 /// The check logic for a tip.
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)]
 pub enum Check {
     /// Flag every line whose *original log line* (message) matches the regex.
     PatternMatch { regex: Regex },
@@ -253,213 +254,220 @@ fn load_tip_file(path: &Path) -> anyhow::Result<Tip> {
     let applies_to = parse_tip_applies_to(raw.check.applies_to.as_deref())?;
     let enabled = raw.enabled.unwrap_or(true);
 
-    let check =
-        match raw.check.r#type.as_str() {
-            "pattern_match" => {
-                let pat = raw
-                    .check
-                    .pattern
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("pattern_match requires 'pattern'"))?;
-                let regex = Regex::new(pat)?;
-                Check::PatternMatch { regex }
+    let check = match raw.check.r#type.as_str() {
+        "pattern_match" => {
+            let pat = raw
+                .check
+                .pattern
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("pattern_match requires 'pattern'"))?;
+            let regex = Regex::new(pat)?;
+            Check::PatternMatch { regex }
+        }
+        "contains_any_patterns" => {
+            let pats = raw
+                .check
+                .patterns
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("contains_any_patterns requires 'patterns'"))?;
+            if pats.is_empty() {
+                anyhow::bail!("contains_any_patterns requires at least one pattern");
             }
-            "contains_any_patterns" => {
-                let pats =
-                    raw.check.patterns.as_ref().ok_or_else(|| {
-                        anyhow::anyhow!("contains_any_patterns requires 'patterns'")
-                    })?;
-                if pats.is_empty() {
-                    anyhow::bail!("contains_any_patterns requires at least one pattern");
-                }
-                let regexes: anyhow::Result<Vec<Regex>> = pats
-                    .iter()
-                    .map(|p| Regex::new(p).map_err(Into::into))
-                    .collect();
-                Check::ContainsAnyPatterns { regexes: regexes? }
+            let regexes: anyhow::Result<Vec<Regex>> = pats
+                .iter()
+                .map(|p| Regex::new(p).map_err(Into::into))
+                .collect();
+            Check::ContainsAnyPatterns { regexes: regexes? }
+        }
+        "time_delta" => {
+            let secs = raw
+                .check
+                .threshold_secs
+                .ok_or_else(|| anyhow::anyhow!("time_delta requires 'threshold_secs'"))?;
+            let mark = match raw.check.mark.as_deref() {
+                Some("first_last") => TimeDeltaMark::FirstLast,
+                Some("last") | None => TimeDeltaMark::Last,
+                Some(other) => anyhow::bail!("Unknown mark type: {other}"),
+            };
+            Check::TimeDelta {
+                threshold_ms: secs as i64 * 1000,
+                mark,
             }
-            "time_delta" => {
-                let secs = raw
-                    .check
-                    .threshold_secs
-                    .ok_or_else(|| anyhow::anyhow!("time_delta requires 'threshold_secs'"))?;
-                let mark = match raw.check.mark.as_deref() {
-                    Some("first_last") => TimeDeltaMark::FirstLast,
-                    Some("last") | None => TimeDeltaMark::Last,
-                    Some(other) => anyhow::bail!("Unknown mark type: {other}"),
-                };
-                Check::TimeDelta {
-                    threshold_ms: secs as i64 * 1000,
-                    mark,
-                }
+        }
+        "time_gap" => {
+            let secs = raw
+                .check
+                .threshold_secs
+                .ok_or_else(|| anyhow::anyhow!("time_gap requires 'threshold_secs'"))?;
+            let mark = match raw.check.mark.as_deref() {
+                Some("first_last") => TimeDeltaMark::FirstLast,
+                Some("last") | None => TimeDeltaMark::Last,
+                Some(other) => anyhow::bail!("Unknown mark type: {other}"),
+            };
+            Check::TimeGap {
+                threshold_ms: secs as i64 * 1000,
+                mark,
             }
-            "time_gap" => {
-                let secs = raw
-                    .check
-                    .threshold_secs
-                    .ok_or_else(|| anyhow::anyhow!("time_gap requires 'threshold_secs'"))?;
-                let mark = match raw.check.mark.as_deref() {
-                    Some("first_last") => TimeDeltaMark::FirstLast,
-                    Some("last") | None => TimeDeltaMark::Last,
-                    Some(other) => anyhow::bail!("Unknown mark type: {other}"),
-                };
-                Check::TimeGap {
-                    threshold_ms: secs as i64 * 1000,
-                    mark,
-                }
+        }
+        "step_duration" => {
+            let step = raw
+                .check
+                .step
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("step_duration requires 'step'"))?
+                .trim()
+                .to_string();
+            if step.is_empty() {
+                anyhow::bail!("step_duration requires non-empty 'step'");
             }
-            "step_duration" => {
-                let step = raw
-                    .check
-                    .step
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("step_duration requires 'step'"))?
-                    .trim()
-                    .to_string();
-                if step.is_empty() {
-                    anyhow::bail!("step_duration requires non-empty 'step'");
-                }
-                let secs = raw
-                    .check
-                    .threshold_secs
-                    .ok_or_else(|| anyhow::anyhow!("step_duration requires 'threshold_secs'"))?;
-                let mark = match raw.check.mark.as_deref() {
-                    Some("first_last") => TimeDeltaMark::FirstLast,
-                    Some("last") | None => TimeDeltaMark::Last,
-                    Some(other) => anyhow::bail!("Unknown mark type: {other}"),
-                };
-                Check::StepDuration {
-                    step,
-                    threshold_ms: secs as i64 * 1000,
-                    mark,
-                }
+            let secs = raw
+                .check
+                .threshold_secs
+                .ok_or_else(|| anyhow::anyhow!("step_duration requires 'threshold_secs'"))?;
+            let mark = match raw.check.mark.as_deref() {
+                Some("first_last") => TimeDeltaMark::FirstLast,
+                Some("last") | None => TimeDeltaMark::Last,
+                Some(other) => anyhow::bail!("Unknown mark type: {other}"),
+            };
+            Check::StepDuration {
+                step,
+                threshold_ms: secs as i64 * 1000,
+                mark,
             }
-            "level_count" => {
-                let level_str = raw
-                    .check
-                    .level
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("level_count requires 'level'"))?;
-                let level = parse_log_level(level_str)?;
-                let threshold = raw
-                    .check
-                    .threshold
-                    .ok_or_else(|| anyhow::anyhow!("level_count requires 'threshold'"))?;
-                Check::LevelCount { level, threshold }
+        }
+        "level_count" => {
+            let level_str = raw
+                .check
+                .level
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("level_count requires 'level'"))?;
+            let level = parse_log_level(level_str)?;
+            let threshold = raw
+                .check
+                .threshold
+                .ok_or_else(|| anyhow::anyhow!("level_count requires 'threshold'"))?;
+            Check::LevelCount { level, threshold }
+        }
+        "missing_pattern" => {
+            let pat = raw
+                .check
+                .pattern
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("missing_pattern requires 'pattern'"))?;
+            let regex = Regex::new(pat)?;
+            Check::MissingPattern { regex }
+        }
+        "missing_any_pattern" => {
+            let pats = raw
+                .check
+                .patterns
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("missing_any_pattern requires 'patterns'"))?;
+            if pats.is_empty() {
+                anyhow::bail!("missing_any_pattern requires at least one pattern");
             }
-            "missing_pattern" => {
-                let pat = raw
-                    .check
-                    .pattern
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("missing_pattern requires 'pattern'"))?;
-                let regex = Regex::new(pat)?;
-                Check::MissingPattern { regex }
+            let regexes: anyhow::Result<Vec<Regex>> = pats
+                .iter()
+                .map(|p| Regex::new(p).map_err(Into::into))
+                .collect();
+            Check::MissingAnyPattern {
+                patterns: pats.clone(),
+                regexes: regexes?,
             }
-            "missing_any_pattern" => {
-                let pats =
-                    raw.check.patterns.as_ref().ok_or_else(|| {
-                        anyhow::anyhow!("missing_any_pattern requires 'patterns'")
-                    })?;
-                if pats.is_empty() {
-                    anyhow::bail!("missing_any_pattern requires at least one pattern");
-                }
-                let regexes: anyhow::Result<Vec<Regex>> = pats
-                    .iter()
-                    .map(|p| Regex::new(p).map_err(Into::into))
-                    .collect();
-                Check::MissingAnyPattern {
-                    patterns: pats.clone(),
-                    regexes: regexes?,
-                }
+        }
+        "version_check" => {
+            let pat = raw
+                .check
+                .pattern
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("version_check requires 'pattern'"))?;
+            let regex = Regex::new(pat)?;
+            if regex.captures_len() < 2 {
+                anyhow::bail!("version_check 'pattern' must contain at least one capture group");
             }
-            "version_check" => {
-                let pat = raw
-                    .check
-                    .pattern
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("version_check requires 'pattern'"))?;
-                let regex = Regex::new(pat)?;
-                if regex.captures_len() < 2 {
-                    anyhow::bail!("version_check 'pattern' must contain at least one capture group");
-                }
-                let min_version = raw
-                    .check
-                    .min_version
-                    .as_deref()
-                    .map(parse_version_triple)
-                    .transpose()
-                    .map_err(|e| anyhow::anyhow!("Invalid min_version: {e}"))?;
-                let max_version = raw
-                    .check
-                    .max_version
-                    .as_deref()
-                    .map(parse_version_triple)
-                    .transpose()
-                    .map_err(|e| anyhow::anyhow!("Invalid max_version: {e}"))?;
-                if min_version.is_none() && max_version.is_none() {
-                    anyhow::bail!("version_check requires at least one of 'min_version' or 'max_version'");
-                }
-                Check::VersionCheck { regex, min_version, max_version }
+            let min_version = raw
+                .check
+                .min_version
+                .as_deref()
+                .map(parse_version_triple)
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid min_version: {e}"))?;
+            let max_version = raw
+                .check
+                .max_version
+                .as_deref()
+                .map(parse_version_triple)
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid max_version: {e}"))?;
+            if min_version.is_none() && max_version.is_none() {
+                anyhow::bail!(
+                    "version_check requires at least one of 'min_version' or 'max_version'"
+                );
             }
-            "action_version_check" => {
-                let action = raw
-                    .check
-                    .action
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("action_version_check requires 'action'"))?
-                    .trim()
-                    .to_string();
-                if action.is_empty() {
-                    anyhow::bail!("action_version_check 'action' must be non-empty");
-                }
-                if !action.contains('/') {
-                    anyhow::bail!(
-                        "action_version_check 'action' must be in 'owner/repo' format, got {action:?}"
-                    );
-                }
-                // Build a regex that matches the download-header line for this action,
-                // regardless of whether the ref is a tag (@v4) or a full/partial SHA.
-                // Covers the older "immutable action package" format and the newer
-                // "action repository" format introduced in 2026.
-                let escaped = regex::escape(&action);
-                let action_regex = Regex::new(&format!(
-                    r"(?:Download immutable action package|Download action repository) '{escaped}@"
-                ))?;
-                // Matches the "Version: X.Y.Z" line that immediately follows (older format).
-                let version_regex = Regex::new(r"^Version: (\d+\.\d+\.\d+)$")?;
-                // Fallback for newer format: extract major version from a tag ref like `@v4`.
-                let tag_version_regex = Regex::new(r"@v(\d+)")?;
-                let min_version = raw
-                    .check
-                    .min_version
-                    .as_deref()
-                    .map(parse_version_triple)
-                    .transpose()
-                    .map_err(|e| anyhow::anyhow!("Invalid min_version: {e}"))?;
-                let max_version = raw
-                    .check
-                    .max_version
-                    .as_deref()
-                    .map(parse_version_triple)
-                    .transpose()
-                    .map_err(|e| anyhow::anyhow!("Invalid max_version: {e}"))?;
-                if min_version.is_none() && max_version.is_none() {
-                    anyhow::bail!(
-                        "action_version_check requires at least one of 'min_version' or 'max_version'"
-                    );
-                }
-                Check::ActionVersionCheck {
-                    action,
-                    action_regex,
-                    version_regex,
-                    tag_version_regex,
-                    min_version,
-                    max_version,
-                }
+            Check::VersionCheck {
+                regex,
+                min_version,
+                max_version,
             }
-            other => anyhow::bail!("Unknown check type: {other}"),
-        };
+        }
+        "action_version_check" => {
+            let action = raw
+                .check
+                .action
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("action_version_check requires 'action'"))?
+                .trim()
+                .to_string();
+            if action.is_empty() {
+                anyhow::bail!("action_version_check 'action' must be non-empty");
+            }
+            if !action.contains('/') {
+                anyhow::bail!(
+                    "action_version_check 'action' must be in 'owner/repo' format, got {action:?}"
+                );
+            }
+            // Build a regex that matches the download-header line for this action,
+            // regardless of whether the ref is a tag (@v4) or a full/partial SHA.
+            // Covers the older "immutable action package" format and the newer
+            // "action repository" format introduced in 2026.
+            let escaped = regex::escape(&action);
+            let action_regex = Regex::new(&format!(
+                r"(?:Download immutable action package|Download action repository) '{escaped}@"
+            ))?;
+            // Matches the "Version: X.Y.Z" line that immediately follows (older format).
+            let version_regex = Regex::new(r"^Version: (\d+\.\d+\.\d+)$")?;
+            // Fallback for newer format: extract major version from a tag ref like `@v4`.
+            let tag_version_regex = Regex::new(r"@v(\d+)")?;
+            let min_version = raw
+                .check
+                .min_version
+                .as_deref()
+                .map(parse_version_triple)
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid min_version: {e}"))?;
+            let max_version = raw
+                .check
+                .max_version
+                .as_deref()
+                .map(parse_version_triple)
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid max_version: {e}"))?;
+            if min_version.is_none() && max_version.is_none() {
+                anyhow::bail!(
+                    "action_version_check requires at least one of 'min_version' or 'max_version'"
+                );
+            }
+            Check::ActionVersionCheck {
+                action,
+                action_regex,
+                version_regex,
+                tag_version_regex,
+                min_version,
+                max_version,
+            }
+        }
+        other => anyhow::bail!("Unknown check type: {other}"),
+    };
 
     Ok(Tip {
         id: raw.id,
@@ -730,9 +738,18 @@ pub fn save_tip(input: SaveTipInput<'_>) -> anyhow::Result<()> {
             mark: input.mark.filter(|s| !s.is_empty()).map(|s| s.to_string()),
             level: input.level.filter(|s| !s.is_empty()).map(|s| s.to_string()),
             threshold: input.threshold,
-            min_version: input.min_version.filter(|s| !s.is_empty()).map(|s| s.to_string()),
-            max_version: input.max_version.filter(|s| !s.is_empty()).map(|s| s.to_string()),
-            action: input.action.filter(|s| !s.is_empty()).map(|s| s.to_string()),
+            min_version: input
+                .min_version
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string()),
+            max_version: input
+                .max_version
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string()),
+            action: input
+                .action
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string()),
         },
     };
 
@@ -810,9 +827,15 @@ fn parse_version_triple(s: &str) -> anyhow::Result<[u64; 3]> {
     if parts.len() != 3 {
         anyhow::bail!("expected MAJOR.MINOR.PATCH, got {s:?}");
     }
-    let major = parts[0].parse::<u64>().map_err(|_| anyhow::anyhow!("invalid major in {s:?}"))?;
-    let minor = parts[1].parse::<u64>().map_err(|_| anyhow::anyhow!("invalid minor in {s:?}"))?;
-    let patch = parts[2].parse::<u64>().map_err(|_| anyhow::anyhow!("invalid patch in {s:?}"))?;
+    let major = parts[0]
+        .parse::<u64>()
+        .map_err(|_| anyhow::anyhow!("invalid major in {s:?}"))?;
+    let minor = parts[1]
+        .parse::<u64>()
+        .map_err(|_| anyhow::anyhow!("invalid minor in {s:?}"))?;
+    let patch = parts[2]
+        .parse::<u64>()
+        .map_err(|_| anyhow::anyhow!("invalid patch in {s:?}"))?;
     Ok([major, minor, patch])
 }
 
@@ -1275,7 +1298,11 @@ fn eval_version_check(
             String::new()
         };
 
-        let marked_lines = if triggered { vec![entry.line_number] } else { Vec::new() };
+        let marked_lines = if triggered {
+            vec![entry.line_number]
+        } else {
+            Vec::new()
+        };
 
         return TipResult {
             tip: tip.clone(),
@@ -1307,6 +1334,7 @@ fn eval_version_check(
 ///   `Download action repository 'owner/repo@<ref>' (SHA:...)`
 ///   Version is inferred from the tag portion of `<ref>` (e.g. `v4` → `4.0.0`).
 ///   SHA-only refs without a detectable version tag are skipped.
+#[allow(clippy::too_many_arguments)]
 fn eval_action_version_check(
     tip: &Tip,
     entries: &[LogEntry],
@@ -1338,25 +1366,24 @@ fn eval_action_version_check(
         let Some(ver_entry) = version_entry else {
             // Newer runner format has no separate Version line; fall back to the
             // major version encoded in the tag reference (e.g. `@v4` → 4.0.0).
-            if let Some(caps) = tag_version_regex.captures(&entry.message) {
-                if let Some(major_str) = caps.get(1) {
-                    if let Ok(major) = major_str.as_str().parse::<u64>() {
-                        let found = [major, 0, 0];
-                        let below_min = min_version.is_some_and(|min| found < min);
-                        let above_max = max_version.is_some_and(|max| found > max);
-                        if below_min || above_max {
-                            marked_lines.push(entry.line_number);
-                            if first_detail.is_empty() {
-                                let found_str = format_version(found);
-                                first_detail = if below_min {
-                                    let min_str = format_version(min_version.unwrap());
-                                    format!("{action} version {found_str} is below minimum {min_str}")
-                                } else {
-                                    let max_str = format_version(max_version.unwrap());
-                                    format!("{action} version {found_str} is above maximum {max_str}")
-                                };
-                            }
-                        }
+            if let Some(caps) = tag_version_regex.captures(&entry.message)
+                && let Some(major_str) = caps.get(1)
+                && let Ok(major) = major_str.as_str().parse::<u64>()
+            {
+                let found = [major, 0, 0];
+                let below_min = min_version.is_some_and(|min| found < min);
+                let above_max = max_version.is_some_and(|max| found > max);
+                if below_min || above_max {
+                    marked_lines.push(entry.line_number);
+                    if first_detail.is_empty() {
+                        let found_str = format_version(found);
+                        first_detail = if below_min {
+                            let min_str = format_version(min_version.unwrap());
+                            format!("{action} version {found_str} is below minimum {min_str}")
+                        } else {
+                            let max_str = format_version(max_version.unwrap());
+                            format!("{action} version {found_str} is above maximum {max_str}")
+                        };
                     }
                 }
             }
@@ -1970,7 +1997,10 @@ pattern = "error"
         let tip = action_version_check_tip("actions/checkout", "6.0.0");
         let results = evaluate_tips_for_log(&[tip], &entries, LogKind::Workflow);
         assert_eq!(results.len(), 1);
-        assert!(!results[0].triggered, "v6 should not trigger on 6.0.0 floor");
+        assert!(
+            !results[0].triggered,
+            "v6 should not trigger on 6.0.0 floor"
+        );
     }
 
     #[test]
@@ -1981,7 +2011,10 @@ pattern = "error"
         let tip = action_version_check_tip("actions/checkout", "6.0.0");
         let results = evaluate_tips_for_log(&[tip], &entries, LogKind::Workflow);
         assert_eq!(results.len(), 1);
-        assert!(!results[0].triggered, "bare SHA ref should not trigger (version unknown)");
+        assert!(
+            !results[0].triggered,
+            "bare SHA ref should not trigger (version unknown)"
+        );
     }
 
     #[test]

--- a/src/routes/compare.rs
+++ b/src/routes/compare.rs
@@ -1,0 +1,589 @@
+//! Compare-view routes — pick two analyses (existing or newly uploaded)
+//! and render a structured diff between them.
+
+use std::sync::Arc;
+
+use askama::Template;
+use axum::extract::{Path, Query, State};
+use axum::response::{Html, Redirect};
+use serde::Deserialize;
+
+use crate::config::AppConfig;
+use crate::models::compare::{self, RunnerImage};
+use crate::models::diff::{self, ComparisonReport, JobStepGroup, PairedActionRef, PairedStep};
+use crate::models::log_parser::ActionReference;
+use crate::routes::home::list_analyses;
+use crate::routes::upload::{
+    UploadError, analysis_id_from_filename, extract_uploaded_zip, sanitize_analysis_id,
+};
+
+// ── Form / query ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Default, Deserialize)]
+pub struct CompareQuery {
+    #[serde(default)]
+    pub fuzzy: Option<String>,
+}
+
+impl CompareQuery {
+    fn is_fuzzy(&self) -> bool {
+        matches!(
+            self.fuzzy.as_deref(),
+            Some("1") | Some("true") | Some("on") | Some("yes")
+        )
+    }
+}
+
+// ── Template view models ─────────────────────────────────────────────────────
+
+/// Display row for a paired action reference.
+#[allow(dead_code)]
+struct ActionPairRow {
+    owner_repo_path: String,
+    github_url: String,
+    a_reference: String,
+    b_reference: String,
+    differs: bool,
+}
+
+/// Display row for an action reference present on only one side.
+#[allow(dead_code)]
+struct ActionOnlyRow {
+    owner_repo_path: String,
+    github_url: String,
+    reference: String,
+}
+
+/// Display row for a paired step.
+#[allow(dead_code)]
+struct StepRow {
+    label: String,
+    a_duration_display: String,
+    b_duration_display: String,
+    delta_display: String,
+    delta_class: &'static str,
+}
+
+/// Display group of paired steps (one job folder).
+#[allow(dead_code)]
+struct StepGroupView {
+    job_folder: String,
+    steps: Vec<StepRow>,
+}
+
+/// Unmatched step row.
+#[allow(dead_code)]
+struct UnmatchedStepRow {
+    job_folder: String,
+    step_file: String,
+    duration_display: String,
+}
+
+#[derive(Template)]
+#[template(path = "compare.html")]
+struct CompareFormTemplate {
+    analyses: Vec<String>,
+}
+
+#[derive(Template)]
+#[template(path = "compare_result.html")]
+#[allow(dead_code)]
+struct CompareResultTemplate {
+    a_id: String,
+    b_id: String,
+    fuzzy: bool,
+    // Runner type (classified)
+    runner_type_a: String,
+    runner_type_b: String,
+    runner_type_differs: bool,
+    // Runner identity (always render)
+    runner_version_a: String,
+    runner_version_b: String,
+    runner_version_differs: bool,
+    requested_labels_a: String,
+    requested_labels_b: String,
+    requested_labels_differs: bool,
+    // Self-hosted identity (only render when at least one side is self-hosted)
+    self_hosted_present: bool,
+    self_hosted_runner_name_a: String,
+    self_hosted_runner_name_b: String,
+    self_hosted_runner_group_a: String,
+    self_hosted_runner_group_b: String,
+    self_hosted_machine_name_a: String,
+    self_hosted_machine_name_b: String,
+    self_hosted_identity_differs: bool,
+    // Runner image (hosted-only signal; rendered when at least one side reports it)
+    runner_image_present: bool,
+    runner_image_a_image: String,
+    runner_image_a_version: String,
+    runner_image_b_image: String,
+    runner_image_b_version: String,
+    runner_image_differs: bool,
+    runner_image_a_reported: bool,
+    runner_image_b_reported: bool,
+    // Azure region
+    azure_region_a: String,
+    azure_region_b: String,
+    azure_region_differs: bool,
+    azure_region_present: bool,
+    // Diagnostic logs
+    diagnostic_logs_a: bool,
+    diagnostic_logs_b: bool,
+    diagnostic_logs_differs: bool,
+    // Action refs
+    action_pairs: Vec<ActionPairRow>,
+    action_only_in_a: Vec<ActionOnlyRow>,
+    action_only_in_b: Vec<ActionOnlyRow>,
+    // Steps
+    step_groups: Vec<StepGroupView>,
+    steps_only_in_a: Vec<UnmatchedStepRow>,
+    steps_only_in_b: Vec<UnmatchedStepRow>,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum CompareError {
+    #[error("{0}")]
+    NotFound(String),
+
+    #[error("{0}")]
+    BadRequest(String),
+
+    #[error("{0}")]
+    Internal(String),
+
+    #[error(transparent)]
+    Upload(#[from] UploadError),
+}
+
+impl axum::response::IntoResponse for CompareError {
+    fn into_response(self) -> axum::response::Response {
+        use axum::http::StatusCode;
+
+        // UploadError already implements IntoResponse — delegate to it.
+        if let CompareError::Upload(e) = self {
+            return e.into_response();
+        }
+
+        let status = match &self {
+            CompareError::NotFound(_) => StatusCode::NOT_FOUND,
+            CompareError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            CompareError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            CompareError::Upload(_) => unreachable!(),
+        };
+
+        let message = self.to_string();
+        tracing::error!(error = %message, "Compare error");
+
+        #[derive(Template)]
+        #[template(path = "error.html")]
+        struct ErrorTemplate {
+            title: String,
+            message: String,
+        }
+
+        let template = ErrorTemplate {
+            title: format!("{status}"),
+            message,
+        };
+
+        match template.render() {
+            Ok(html) => (status, Html(html)).into_response(),
+            Err(_) => (status, "An error occurred").into_response(),
+        }
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `GET /compare` — render the form (dropdowns + dual-upload).
+pub async fn compare_form(
+    State(config): State<Arc<AppConfig>>,
+) -> Result<Html<String>, CompareError> {
+    let analyses = list_analyses(&config.upload_dir);
+    let template = CompareFormTemplate { analyses };
+    template
+        .render()
+        .map(Html)
+        .map_err(|e| CompareError::Internal(format!("Template error: {e}")))
+}
+
+/// Form payload for `POST /compare/upload`.
+struct ComparePairInputs {
+    a_id: String,
+    b_id: String,
+}
+
+/// `POST /compare/upload` — accept any combination of existing analysis IDs
+/// and freshly-uploaded ZIPs (one per side), extract uploads, then redirect
+/// to `/compare/{a}/{b}`.
+pub async fn compare_upload(
+    State(config): State<Arc<AppConfig>>,
+    mut multipart: axum_extra::extract::Multipart,
+) -> Result<Redirect, CompareError> {
+    let mut existing_a: Option<String> = None;
+    let mut existing_b: Option<String> = None;
+    let mut zip_a: Option<(String, Vec<u8>)> = None;
+    let mut zip_b: Option<(String, Vec<u8>)> = None;
+    let mut fuzzy = false;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| CompareError::BadRequest(format!("Failed to read multipart field: {e}")))?
+    {
+        let name = field.name().unwrap_or("").to_string();
+        match name.as_str() {
+            "existing_a" => {
+                let v = field.text().await.unwrap_or_default();
+                if !v.is_empty() {
+                    existing_a = Some(v);
+                }
+            }
+            "existing_b" => {
+                let v = field.text().await.unwrap_or_default();
+                if !v.is_empty() {
+                    existing_b = Some(v);
+                }
+            }
+            "zipfile_a" => {
+                let filename = field.file_name().unwrap_or("upload.zip").to_string();
+                let data = field.bytes().await.map_err(|e| {
+                    CompareError::BadRequest(format!("Failed to read upload A: {e}"))
+                })?;
+                if !data.is_empty() {
+                    zip_a = Some((filename, data.to_vec()));
+                }
+            }
+            "zipfile_b" => {
+                let filename = field.file_name().unwrap_or("upload.zip").to_string();
+                let data = field.bytes().await.map_err(|e| {
+                    CompareError::BadRequest(format!("Failed to read upload B: {e}"))
+                })?;
+                if !data.is_empty() {
+                    zip_b = Some((filename, data.to_vec()));
+                }
+            }
+            "fuzzy" => {
+                let v = field.text().await.unwrap_or_default();
+                if matches!(v.as_str(), "1" | "true" | "on" | "yes") {
+                    fuzzy = true;
+                }
+            }
+            _ => {
+                // Ignore unknown fields.
+                let _ = field.bytes().await;
+            }
+        }
+    }
+
+    let inputs = resolve_pair_inputs(&config, existing_a, existing_b, zip_a, zip_b).await?;
+
+    let suffix = if fuzzy { "?fuzzy=1" } else { "" };
+    Ok(Redirect::to(&format!(
+        "/compare/{}/{}{}",
+        inputs.a_id, inputs.b_id, suffix
+    )))
+}
+
+async fn resolve_pair_inputs(
+    config: &AppConfig,
+    existing_a: Option<String>,
+    existing_b: Option<String>,
+    zip_a: Option<(String, Vec<u8>)>,
+    zip_b: Option<(String, Vec<u8>)>,
+) -> Result<ComparePairInputs, CompareError> {
+    let a_id = resolve_side(config, "A", existing_a, zip_a).await?;
+    let b_id = resolve_side(config, "B", existing_b, zip_b).await?;
+
+    if a_id == b_id {
+        return Err(CompareError::BadRequest(
+            "Pick two different analyses to compare.".to_string(),
+        ));
+    }
+    Ok(ComparePairInputs { a_id, b_id })
+}
+
+async fn resolve_side(
+    config: &AppConfig,
+    label: &str,
+    existing: Option<String>,
+    zip: Option<(String, Vec<u8>)>,
+) -> Result<String, CompareError> {
+    match (existing, zip) {
+        (Some(_), Some(_)) => Err(CompareError::BadRequest(format!(
+            "Side {label}: pick an existing analysis OR upload a ZIP, not both."
+        ))),
+        (Some(id), None) => {
+            // Validate the existing ID and that the directory exists.
+            if !is_valid_id(&id) {
+                return Err(CompareError::BadRequest(format!(
+                    "Side {label}: invalid analysis ID '{id}'."
+                )));
+            }
+            if !config.upload_dir.join(&id).is_dir() {
+                return Err(CompareError::NotFound(format!(
+                    "Side {label}: analysis '{id}' not found."
+                )));
+            }
+            Ok(id)
+        }
+        (None, Some((filename, data))) => {
+            let id = analysis_id_from_filename(&filename);
+            sanitize_analysis_id(&filename, &id).map_err(CompareError::Upload)?;
+            extract_uploaded_zip(&config.upload_dir, &id, data).await?;
+            Ok(id)
+        }
+        (None, None) => Err(CompareError::BadRequest(format!(
+            "Side {label}: choose an existing analysis or upload a ZIP."
+        ))),
+    }
+}
+
+/// `GET /compare/{a}/{b}` — render the side-by-side comparison.
+pub async fn compare_view(
+    State(config): State<Arc<AppConfig>>,
+    Path((a_id, b_id)): Path<(String, String)>,
+    Query(query): Query<CompareQuery>,
+) -> Result<Html<String>, CompareError> {
+    if !is_valid_id(&a_id) || !is_valid_id(&b_id) {
+        return Err(CompareError::NotFound(
+            "Invalid analysis ID in compare URL.".to_string(),
+        ));
+    }
+    let a_dir = config.upload_dir.join(&a_id);
+    let b_dir = config.upload_dir.join(&b_id);
+    if !a_dir.is_dir() {
+        return Err(CompareError::NotFound(format!(
+            "Analysis '{a_id}' not found."
+        )));
+    }
+    if !b_dir.is_dir() {
+        return Err(CompareError::NotFound(format!(
+            "Analysis '{b_id}' not found."
+        )));
+    }
+
+    let fuzzy = query.is_fuzzy();
+
+    let (a_id_for_task, b_id_for_task) = (a_id.clone(), b_id.clone());
+    let (summary_a, summary_b) = tokio::task::spawn_blocking(move || {
+        let a = compare::summarize_archive(&a_id_for_task, &a_dir);
+        let b = compare::summarize_archive(&b_id_for_task, &b_dir);
+        (a, b)
+    })
+    .await
+    .map_err(|e| CompareError::Internal(format!("Task join error: {e}")))?;
+
+    let report = diff::compare(&summary_a, &summary_b, fuzzy);
+    let template = build_result_template(&report);
+
+    template
+        .render()
+        .map(Html)
+        .map_err(|e| CompareError::Internal(format!("Template error: {e}")))
+}
+
+fn is_valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+}
+
+fn build_result_template(report: &ComparisonReport) -> CompareResultTemplate {
+    let runner_image_a_reported = report.runner_image.a.is_some();
+    let runner_image_b_reported = report.runner_image.b.is_some();
+    let runner_image_present = runner_image_a_reported || runner_image_b_reported;
+
+    let runner_image_a = report.runner_image.a.clone().unwrap_or(RunnerImage {
+        image: "—".into(),
+        version: "—".into(),
+    });
+    let runner_image_b = report.runner_image.b.clone().unwrap_or(RunnerImage {
+        image: "—".into(),
+        version: "—".into(),
+    });
+
+    let azure_region_present = report.azure_region.a.is_some() || report.azure_region.b.is_some();
+
+    // Self-hosted identity fields render when at least one side is self-hosted.
+    let self_hosted_present =
+        report.self_hosted_identity.a.is_some() || report.self_hosted_identity.b.is_some();
+    let id_a = report.self_hosted_identity.a.as_ref();
+    let id_b = report.self_hosted_identity.b.as_ref();
+
+    let action_pairs: Vec<ActionPairRow> = report
+        .action_refs
+        .paired
+        .iter()
+        .map(paired_action_row)
+        .collect();
+    let action_only_in_a: Vec<ActionOnlyRow> = report
+        .action_refs
+        .only_in_a
+        .iter()
+        .map(action_only_row)
+        .collect();
+    let action_only_in_b: Vec<ActionOnlyRow> = report
+        .action_refs
+        .only_in_b
+        .iter()
+        .map(action_only_row)
+        .collect();
+
+    let step_groups: Vec<StepGroupView> = report
+        .steps
+        .paired_by_job
+        .iter()
+        .map(job_step_group_view)
+        .collect();
+    let steps_only_in_a: Vec<UnmatchedStepRow> = report
+        .steps
+        .only_in_a
+        .iter()
+        .map(unmatched_step_row)
+        .collect();
+    let steps_only_in_b: Vec<UnmatchedStepRow> = report
+        .steps
+        .only_in_b
+        .iter()
+        .map(unmatched_step_row)
+        .collect();
+
+    CompareResultTemplate {
+        a_id: report.a_id.clone(),
+        b_id: report.b_id.clone(),
+        fuzzy: report.fuzzy,
+        runner_type_a: report.runner_type.a.label().to_string(),
+        runner_type_b: report.runner_type.b.label().to_string(),
+        runner_type_differs: report.runner_type.differs,
+        runner_version_a: opt_or_dash(&report.runner_version.a),
+        runner_version_b: opt_or_dash(&report.runner_version.b),
+        runner_version_differs: report.runner_version.differs,
+        requested_labels_a: opt_or_dash(&report.requested_labels.a),
+        requested_labels_b: opt_or_dash(&report.requested_labels.b),
+        requested_labels_differs: report.requested_labels.differs,
+        self_hosted_present,
+        self_hosted_runner_name_a: identity_field(id_a, |i| &i.runner_name),
+        self_hosted_runner_name_b: identity_field(id_b, |i| &i.runner_name),
+        self_hosted_runner_group_a: identity_field(id_a, |i| &i.runner_group),
+        self_hosted_runner_group_b: identity_field(id_b, |i| &i.runner_group),
+        self_hosted_machine_name_a: identity_field(id_a, |i| &i.machine_name),
+        self_hosted_machine_name_b: identity_field(id_b, |i| &i.machine_name),
+        self_hosted_identity_differs: report.self_hosted_identity.differs,
+        runner_image_present,
+        runner_image_a_image: runner_image_a.image,
+        runner_image_a_version: runner_image_a.version,
+        runner_image_b_image: runner_image_b.image,
+        runner_image_b_version: runner_image_b.version,
+        runner_image_differs: report.runner_image.differs,
+        runner_image_a_reported,
+        runner_image_b_reported,
+        azure_region_a: report.azure_region.a.clone().unwrap_or_else(|| "—".into()),
+        azure_region_b: report.azure_region.b.clone().unwrap_or_else(|| "—".into()),
+        azure_region_differs: report.azure_region.differs,
+        azure_region_present,
+        diagnostic_logs_a: report.diagnostic_logs.a,
+        diagnostic_logs_b: report.diagnostic_logs.b,
+        diagnostic_logs_differs: report.diagnostic_logs.differs,
+        action_pairs,
+        action_only_in_a,
+        action_only_in_b,
+        step_groups,
+        steps_only_in_a,
+        steps_only_in_b,
+    }
+}
+
+fn opt_or_dash(value: &Option<String>) -> String {
+    value.clone().unwrap_or_else(|| "—".into())
+}
+
+fn identity_field<F>(identity: Option<&compare::SelfHostedIdentity>, f: F) -> String
+where
+    F: FnOnce(&compare::SelfHostedIdentity) -> &Option<String>,
+{
+    match identity {
+        Some(i) => f(i).clone().unwrap_or_else(|| "—".into()),
+        None => "—".into(),
+    }
+}
+
+fn paired_action_row(p: &PairedActionRef) -> ActionPairRow {
+    ActionPairRow {
+        owner_repo_path: p.owner_repo_path.clone(),
+        github_url: p.github_url.clone(),
+        a_reference: p.a_reference.clone(),
+        b_reference: p.b_reference.clone(),
+        differs: p.differs,
+    }
+}
+
+fn action_only_row(a: &ActionReference) -> ActionOnlyRow {
+    let key = match &a.path {
+        Some(p) => format!("{}/{}{}", a.owner, a.repo, p),
+        None => format!("{}/{}", a.owner, a.repo),
+    };
+    ActionOnlyRow {
+        owner_repo_path: key,
+        github_url: a.github_url(),
+        reference: a.reference.clone(),
+    }
+}
+
+fn job_step_group_view(g: &JobStepGroup) -> StepGroupView {
+    StepGroupView {
+        job_folder: g.job_folder.clone(),
+        steps: g.steps.iter().map(paired_step_row).collect(),
+    }
+}
+
+fn paired_step_row(s: &PairedStep) -> StepRow {
+    let (delta_display, delta_class) = match s.delta_ms {
+        None => ("—".to_string(), "delta-na"),
+        Some(d) if d > 0 => (format!("+{}", format_duration_ms(d)), "delta-slower"),
+        Some(d) if d < 0 => (format!("-{}", format_duration_ms(-d)), "delta-faster"),
+        Some(_) => ("0s".to_string(), "delta-same"),
+    };
+    StepRow {
+        label: s.label.clone(),
+        a_duration_display: format_duration_opt(s.a_duration_ms),
+        b_duration_display: format_duration_opt(s.b_duration_ms),
+        delta_display,
+        delta_class,
+    }
+}
+
+fn unmatched_step_row(s: &compare::StepSummary) -> UnmatchedStepRow {
+    UnmatchedStepRow {
+        job_folder: s.job_folder.clone(),
+        step_file: s.step_file.clone(),
+        duration_display: format_duration_opt(s.duration_ms),
+    }
+}
+
+fn format_duration_opt(ms: Option<i64>) -> String {
+    match ms {
+        Some(ms) => format_duration_ms(ms),
+        None => "—".into(),
+    }
+}
+
+fn format_duration_ms(ms: i64) -> String {
+    if ms < 1000 {
+        return format!("{ms}ms");
+    }
+    let total_secs = ms / 1000;
+    let secs = total_secs % 60;
+    let mins = (total_secs / 60) % 60;
+    let hours = total_secs / 3600;
+    if hours > 0 {
+        format!("{hours}h {mins}m {secs}s")
+    } else if mins > 0 {
+        format!("{mins}m {secs}s")
+    } else {
+        format!("{secs}s")
+    }
+}

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -58,7 +58,7 @@ pub async fn delete_all(State(config): State<Arc<AppConfig>>) -> Result<Redirect
 }
 
 /// Scan the upload directory for existing analysis folders.
-fn list_analyses(upload_dir: &std::path::Path) -> Vec<String> {
+pub(crate) fn list_analyses(upload_dir: &std::path::Path) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(upload_dir) else {
         return Vec::new();
     };

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod analysis;
+pub mod compare;
 pub mod home;
 pub mod settings;
 pub mod upload;

--- a/src/routes/upload.rs
+++ b/src/routes/upload.rs
@@ -7,6 +7,63 @@ use axum::response::Redirect;
 use crate::config::AppConfig;
 use crate::extract::zip_extract;
 
+/// Sanitize an analysis ID derived from an uploaded filename.
+///
+/// Only allows alphanumeric, hyphens, and underscores. Returns the same
+/// `BadRequest` style error used by the upload handler so all callers share
+/// one rejection message.
+pub(crate) fn sanitize_analysis_id(filename: &str, analysis_id: &str) -> Result<(), UploadError> {
+    if !analysis_id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(UploadError::BadRequest(format!(
+            "Invalid filename '{filename}': only alphanumeric characters, hyphens, and underscores are allowed."
+        )));
+    }
+    Ok(())
+}
+
+/// Derive the analysis ID from a filename's stem.
+pub(crate) fn analysis_id_from_filename(filename: &str) -> String {
+    PathBuf::from(filename)
+        .file_stem()
+        .and_then(|s| s.to_str().map(String::from))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Extract a single uploaded ZIP into `<upload_dir>/<analysis_id>/`.
+///
+/// Runs the extraction inside `tokio::task::spawn_blocking` so it does not
+/// block the runtime. Auto-extracts nested ZIPs (e.g. runner-diagnostic-logs).
+pub(crate) async fn extract_uploaded_zip(
+    upload_dir: &std::path::Path,
+    analysis_id: &str,
+    data: Vec<u8>,
+) -> Result<zip_extract::ExtractResult, UploadError> {
+    let output_dir = upload_dir.join(analysis_id);
+    let bytes = data.len();
+    tracing::info!(analysis_id = %analysis_id, bytes, "Processing upload");
+
+    let result = tokio::task::spawn_blocking(move || {
+        let result = zip_extract::extract_zip(&data, &output_dir)?;
+        zip_extract::extract_nested_zips(&output_dir);
+        Ok::<_, zip_extract::ExtractError>(result)
+    })
+    .await
+    .map_err(|e| UploadError::Internal(format!("Task join error: {e}")))?
+    .map_err(UploadError::Extraction)?;
+
+    tracing::info!(
+        analysis_id = %analysis_id,
+        files = result.file_count,
+        total_bytes = result.total_bytes,
+        "Upload extracted successfully"
+    );
+
+    Ok(result)
+}
+
 /// `POST /upload` — accept a ZIP file upload, extract it, redirect to the analysis page.
 pub async fn upload(
     State(config): State<Arc<AppConfig>>,
@@ -35,43 +92,9 @@ pub async fn upload(
         UploadError::BadRequest("No file field named 'zipfile' found in the upload.".into())
     })?;
 
-    // Derive the analysis ID from the filename stem
-    let analysis_id = PathBuf::from(&filename)
-        .file_stem()
-        .and_then(|s| s.to_str().map(String::from))
-        .unwrap_or_else(|| "unknown".to_string());
-
-    // Sanitize the ID: only allow alphanumeric, hyphens, underscores
-    if !analysis_id
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-    {
-        return Err(UploadError::BadRequest(format!(
-            "Invalid filename '{filename}': only alphanumeric characters, hyphens, and underscores are allowed."
-        )));
-    }
-
-    let output_dir = config.upload_dir.join(&analysis_id);
-
-    tracing::info!(analysis_id = %analysis_id, filename = %filename, bytes = data.len(), "Processing upload");
-
-    // Extract the ZIP — run in a blocking task since it does filesystem I/O
-    let result = tokio::task::spawn_blocking(move || {
-        let result = zip_extract::extract_zip(&data, &output_dir)?;
-        // Auto-extract nested ZIPs (e.g. runner-diagnostic-logs/*.zip)
-        zip_extract::extract_nested_zips(&output_dir);
-        Ok::<_, zip_extract::ExtractError>(result)
-    })
-    .await
-    .map_err(|e| UploadError::Internal(format!("Task join error: {e}")))?
-    .map_err(UploadError::Extraction)?;
-
-    tracing::info!(
-        analysis_id = %analysis_id,
-        files = result.file_count,
-        total_bytes = result.total_bytes,
-        "Upload extracted successfully"
-    );
+    let analysis_id = analysis_id_from_filename(&filename);
+    sanitize_analysis_id(&filename, &analysis_id)?;
+    extract_uploaded_zip(&config.upload_dir, &analysis_id, data).await?;
 
     Ok(Redirect::to(&format!("/analysis/{analysis_id}")))
 }

--- a/static/style.css
+++ b/static/style.css
@@ -127,6 +127,27 @@ button:hover {
     background: var(--color-danger-hover);
 }
 
+/* Anchor styled as a button (e.g. "Open comparison tool"). */
+.btn {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.btn-primary {
+    color: #fff;
+    background: var(--color-primary);
+}
+
+.btn-primary:hover {
+    background: var(--color-primary-hover);
+}
+
 /* ── Analysis list ───────────────────────────────────────── */
 .analysis-list {
     list-style: none;
@@ -1197,4 +1218,322 @@ code {
     background: #3d1114;
     color: #f85149;
     border-color: #5a1a1d;
+}
+
+/* ── Compare view ─────────────────────────────────────────── */
+.compare-form-section {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 24px;
+    margin-bottom: 24px;
+}
+
+.compare-form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 16px 0;
+}
+
+@media (max-width: 720px) {
+    .compare-form-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.compare-side {
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 16px;
+    background: var(--color-bg);
+}
+
+.compare-side legend {
+    font-weight: 600;
+    padding: 0 6px;
+}
+
+.compare-side label {
+    display: block;
+    margin: 8px 0 4px;
+    font-weight: 500;
+}
+
+.compare-side select,
+.compare-side input[type="file"] {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+}
+
+.compare-or {
+    color: var(--color-muted);
+    font-size: 0.875rem;
+    margin: 8px 0;
+    text-align: center;
+}
+
+.compare-form {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.compare-fuzzy {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 12px 0;
+    align-self: flex-start;
+}
+
+.compare-fuzzy .tooltip-icon {
+    cursor: help;
+    color: var(--color-muted);
+    font-size: 0.875rem;
+}
+
+.compare-form-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+/* Result page */
+.compare-result-header {
+    margin-bottom: 24px;
+}
+
+.compare-pair {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 12px 16px;
+    margin: 12px 0 16px;
+    padding: 16px 20px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+}
+
+.compare-pair-side {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.compare-pair-side:last-child {
+    text-align: right;
+    align-items: flex-end;
+}
+
+.compare-pair-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+}
+
+.compare-pair-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+    text-decoration: none;
+    overflow-wrap: anywhere;
+    line-height: 1.35;
+}
+
+.compare-pair-name:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
+}
+
+.compare-pair-vs {
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-muted);
+    padding: 0 8px;
+}
+
+@media (max-width: 600px) {
+    .compare-pair {
+        grid-template-columns: 1fr;
+        text-align: left;
+    }
+    .compare-pair-side:last-child {
+        text-align: left;
+        align-items: flex-start;
+    }
+    .compare-pair-vs {
+        padding: 4px 0;
+    }
+}
+
+.compare-vs {
+    color: var(--color-muted);
+    margin: 0 8px;
+    font-weight: 500;
+}
+
+.compare-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+/* Auto-submitting fuzzy-toggle form on the compare result page. Reuses
+   the .compare-fuzzy label styles already defined for the form page. */
+.compare-fuzzy-form {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    margin: 0;
+}
+
+.compare-fuzzy-form .compare-fuzzy {
+    margin: 0;
+}
+
+.compare-fuzzy-note {
+    color: var(--color-muted);
+    font-size: 0.8125rem;
+}
+
+.compare-section {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin-bottom: 16px;
+}
+
+.compare-section h2 {
+    margin-top: 0;
+}
+
+.compare-section h3 {
+    margin-top: 16px;
+    margin-bottom: 8px;
+    font-size: 1rem;
+    color: var(--color-muted);
+}
+
+.compare-table-wrap {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin: 8px 0 16px;
+}
+
+.compare-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.compare-table th,
+.compare-table td {
+    text-align: left;
+    padding: 0.45rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    border-right: 1px solid var(--color-border);
+    vertical-align: top;
+}
+
+.compare-table th:last-child,
+.compare-table td:last-child {
+    border-right: none;
+}
+
+.compare-table tbody tr:last-child th,
+.compare-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.compare-table thead th {
+    background: var(--color-bg);
+    border-bottom: 2px solid var(--color-border);
+    color: var(--color-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.compare-table .col-status {
+    width: 1%;
+    white-space: nowrap;
+}
+
+.compare-table tr.row-differs td,
+.compare-table.row-differs tbody tr td {
+    background: rgba(207, 34, 46, 0.06);
+}
+
+[data-theme="dark"] .compare-table tr.row-differs td,
+[data-theme="dark"] .compare-table.row-differs tbody tr td {
+    background: rgba(248, 81, 73, 0.10);
+}
+
+.muted-note {
+    color: var(--color-muted);
+    font-style: italic;
+    font-size: 0.85em;
+}
+
+.badge-diff {
+    display: inline-block;
+    padding: 2px 8px;
+    background: var(--color-danger);
+    color: #fff;
+    border-radius: 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.badge-same {
+    display: inline-block;
+    padding: 2px 8px;
+    background: #d0d7de;
+    color: #1f2328;
+    border-radius: 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+[data-theme="dark"] .badge-same {
+    background: #30363d;
+    color: #c9d1d9;
+}
+
+.delta-slower {
+    color: var(--color-danger);
+    font-weight: 600;
+}
+
+.delta-faster {
+    color: #1a7f37;
+    font-weight: 600;
+}
+
+[data-theme="dark"] .delta-faster {
+    color: #3fb950;
+}
+
+.delta-same,
+.delta-na {
+    color: var(--color-muted);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}actions-recon{% endblock %}</title>
-    <link rel="stylesheet" href="/static/style.css?v=20260217">
+    <link rel="stylesheet" href="/static/style.css?v=20260430">
 </head>
 <body>
     <header>

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% block title %}Compare analyses — actions-recon{% endblock %}
+
+{% block content %}
+<section class="compare-form-section">
+    <h1>Compare two analyses</h1>
+    <p class="hint">
+        Pick two existing analyses or upload a pair of
+        <span class="tooltip">workflow log ZIPs
+            <span class="tooltip-text">ZIP archives downloaded from GitHub Actions workflow runs. <a href="https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/using-workflow-run-logs#downloading-logs" target="_blank" rel="noopener">Learn more &rarr;</a></span>
+        </span>.
+        The comparison highlights differences in runner type, runner identity, runner image, Azure region, action and reusable workflow versions, diagnostic logs, and step durations.
+    </p>
+
+    <form action="/compare/upload" method="post" enctype="multipart/form-data" class="compare-form">
+        <div class="compare-form-grid">
+            <fieldset class="compare-side">
+                <legend>Side A</legend>
+                {% if !analyses.is_empty() %}
+                <label for="existing_a">Choose an existing analysis</label>
+                <select id="existing_a" name="existing_a">
+                    <option value="">— None —</option>
+                    {% for name in analyses %}
+                    <option value="{{ name }}">{{ name }}.zip</option>
+                    {% endfor %}
+                </select>
+                <p class="compare-or">or</p>
+                {% endif %}
+                <label for="zipfile_a">Upload a .zip file</label>
+                <input type="file" id="zipfile_a" name="zipfile_a" accept=".zip">
+            </fieldset>
+
+            <fieldset class="compare-side">
+                <legend>Side B</legend>
+                {% if !analyses.is_empty() %}
+                <label for="existing_b">Choose an existing analysis</label>
+                <select id="existing_b" name="existing_b">
+                    <option value="">— None —</option>
+                    {% for name in analyses %}
+                    <option value="{{ name }}">{{ name }}.zip</option>
+                    {% endfor %}
+                </select>
+                <p class="compare-or">or</p>
+                {% endif %}
+                <label for="zipfile_b">Upload a .zip file</label>
+                <input type="file" id="zipfile_b" name="zipfile_b" accept=".zip">
+            </fieldset>
+        </div>
+
+        <label class="compare-fuzzy">
+            <input type="checkbox" name="fuzzy" value="1">
+            Fuzzy step matching
+            <span class="tooltip">
+                <span class="tooltip-icon">ⓘ</span>
+                <span class="tooltip-text">Pairs steps across reruns whose normalized names match (digit prefix and .txt stripped, lowercased), even when their leading numbers differ. Useful when steps were reordered.</span>
+            </span>
+        </label>
+
+        <div class="compare-form-actions">
+            <button type="submit">Compare</button>
+            <a href="/" class="btn-back">&larr; Back to Home</a>
+        </div>
+    </form>
+</section>
+{% endblock %}

--- a/templates/compare_result.html
+++ b/templates/compare_result.html
@@ -1,0 +1,383 @@
+{% extends "base.html" %}
+
+{% block title %}Compare: {{ a_id }}.zip vs {{ b_id }}.zip — actions-recon{% endblock %}
+
+{% block content %}
+<section class="compare-result-header">
+    <h1>Compare</h1>
+    <div class="compare-pair">
+        <div class="compare-pair-side">
+            <span class="compare-pair-label">A:</span>
+            <a href="/analysis/{{ a_id }}" class="compare-pair-name">{{ a_id }}.zip</a>
+        </div>
+        <span class="compare-pair-vs">vs.</span>
+        <div class="compare-pair-side">
+            <span class="compare-pair-label">B:</span>
+            <a href="/analysis/{{ b_id }}" class="compare-pair-name">{{ b_id }}.zip</a>
+        </div>
+    </div>
+    <div class="compare-actions">
+        <form method="get" action="/compare/{{ a_id }}/{{ b_id }}" class="compare-fuzzy-form">
+            <label class="compare-fuzzy">
+                <input type="checkbox" name="fuzzy" value="1"
+                    {% if fuzzy %}checked{% endif %}
+                    onchange="this.form.submit()">
+                Fuzzy step matching
+                <span class="tooltip">
+                    <span class="tooltip-icon">ⓘ</span>
+                    <span class="tooltip-text">Pairs steps across reruns whose normalized names match (digit prefix and .txt stripped, lowercased), even when their leading numbers differ. Useful when steps were reordered.</span>
+                </span>
+            </label>
+            <small class="compare-fuzzy-note">Toggling reloads the comparison.</small>
+            <noscript><button type="submit">Apply</button></noscript>
+        </form>
+        <a href="/compare" class="btn-back">&larr; Back to Compare</a>
+    </div>
+</section>
+
+<section class="compare-section">
+    <h2>Runner type</h2>
+    <p class="hint">
+        Classifies each side as GitHub-hosted, self-hosted, or unknown. GitHub-hosted is
+        detected by a <code>Hosted Compute Agent</code> line inside the
+        <code>Runner Image Provisioner</code> group; self-hosted is detected by the
+        <code>Runner name:</code> and <code>Machine name:</code> fields. If neither marker
+        is present the runner is reported as <code>Unknown</code> &mdash; open the
+        side's <code>.zip</code> link above to browse its log files and inspect the header lines directly.
+    </p>
+    <div class="compare-table-wrap">
+    <table class="compare-table {% if runner_type_differs %}row-differs{% endif %}">
+        <thead>
+            <tr>
+                <th>Side A</th>
+                <th>Side B</th>
+                <th class="col-status">Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>{{ runner_type_a }}</td>
+                <td>{{ runner_type_b }}</td>
+                <td class="col-status">
+                    {% if runner_type_differs %}<span class="badge badge-diff">Differs</span>{% else %}<span class="badge badge-same">Same</span>{% endif %}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</section>
+
+<section class="compare-section">
+    <h2>Runner identity</h2>
+    <p class="hint">
+        Fields reported by every runner. Use these to confirm the same runner version was active
+        on both sides and that the job targeted the expected runner labels.
+    </p>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr>
+                <th>Field</th>
+                <th>Side A</th>
+                <th>Side B</th>
+                <th class="col-status">Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="{% if runner_version_differs %}row-differs{% endif %}">
+                <td>Runner version</td>
+                <td><code>{{ runner_version_a }}</code></td>
+                <td><code>{{ runner_version_b }}</code></td>
+                <td class="col-status">
+                    {% if runner_version_differs %}<span class="badge badge-diff">Differs</span>{% else %}<span class="badge badge-same">Same</span>{% endif %}
+                </td>
+            </tr>
+            <tr class="{% if requested_labels_differs %}row-differs{% endif %}">
+                <td>Requested labels</td>
+                <td><code>{{ requested_labels_a }}</code></td>
+                <td><code>{{ requested_labels_b }}</code></td>
+                <td class="col-status">
+                    {% if requested_labels_differs %}<span class="badge badge-diff">Differs</span>{% else %}<span class="badge badge-same">Same</span>{% endif %}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</section>
+
+{% if self_hosted_present %}
+<section class="compare-section">
+    <h2>Self-hosted identity</h2>
+    <p class="hint">
+        Identifying details for self-hosted runners. A repeated <code>Runner name</code> on both
+        sides means the same runner instance picked up each job &mdash; useful when troubleshooting
+        environment-specific issues.
+    </p>
+    <div class="compare-table-wrap">
+    <table class="compare-table {% if self_hosted_identity_differs %}row-differs{% endif %}">
+        <thead>
+            <tr>
+                <th>Field</th>
+                <th>Side A</th>
+                <th>Side B</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Runner name</td>
+                <td><code>{{ self_hosted_runner_name_a }}</code></td>
+                <td><code>{{ self_hosted_runner_name_b }}</code></td>
+            </tr>
+            <tr>
+                <td>Runner group</td>
+                <td><code>{{ self_hosted_runner_group_a }}</code></td>
+                <td><code>{{ self_hosted_runner_group_b }}</code></td>
+            </tr>
+            <tr>
+                <td>Machine name</td>
+                <td><code>{{ self_hosted_machine_name_a }}</code></td>
+                <td><code>{{ self_hosted_machine_name_b }}</code></td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</section>
+{% endif %}
+
+{% if runner_image_present %}
+<section class="compare-section">
+    <h2>Runner image</h2>
+    <p class="hint">
+        The OS image GitHub-hosted runners executed the job on. Drift between reruns on rolling
+        labels such as <code>ubuntu-latest</code>, <code>windows-latest</code>, or
+        <code>macos-latest</code> shows up here. Self-hosted runners do not report an image.
+    </p>
+    <div class="compare-table-wrap">
+    <table class="compare-table {% if runner_image_differs %}row-differs{% endif %}">
+        <thead>
+            <tr>
+                <th>Field</th>
+                <th>Side A</th>
+                <th>Side B</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Image</td>
+                <td>{% if runner_image_a_reported %}{{ runner_image_a_image }}{% else %}<span class="muted-note">Not reported (self-hosted)</span>{% endif %}</td>
+                <td>{% if runner_image_b_reported %}{{ runner_image_b_image }}{% else %}<span class="muted-note">Not reported (self-hosted)</span>{% endif %}</td>
+            </tr>
+            <tr>
+                <td>Version</td>
+                <td>{% if runner_image_a_reported %}{{ runner_image_a_version }}{% else %}—{% endif %}</td>
+                <td>{% if runner_image_b_reported %}{{ runner_image_b_version }}{% else %}—{% endif %}</td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</section>
+{% endif %}
+
+{% if azure_region_present %}
+<section class="compare-section">
+    <h2>Azure region</h2>
+    <p class="hint">
+        GitHub-hosted runners are provisioned across multiple Azure regions. A region difference
+        between reruns can correlate with regional capacity, networking, or service-health issues,
+        and helps spot when multiple jobs share a common region.
+    </p>
+    <div class="compare-table-wrap">
+    <table class="compare-table {% if azure_region_differs %}row-differs{% endif %}">
+        <thead>
+            <tr>
+                <th>Side A</th>
+                <th>Side B</th>
+                <th class="col-status">Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>{{ azure_region_a }}</code></td>
+                <td><code>{{ azure_region_b }}</code></td>
+                <td class="col-status">
+                    {% if azure_region_differs %}<span class="badge badge-diff">Differs</span>{% else %}<span class="badge badge-same">Same</span>{% endif %}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</section>
+{% endif %}
+
+<section class="compare-section">
+    <h2>Diagnostic logs</h2>
+    <p class="hint">
+        Whether the archive includes <code>runner-diagnostic-logs/</code>. The runner uploads
+        these when runner-level debug logging is enabled via <code>ACTIONS_RUNNER_DEBUG=true</code>.
+    </p>
+    <div class="compare-table-wrap">
+    <table class="compare-table {% if diagnostic_logs_differs %}row-differs{% endif %}">
+        <thead>
+            <tr>
+                <th>Side A</th>
+                <th>Side B</th>
+                <th class="col-status">Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>{% if diagnostic_logs_a %}Enabled{% else %}Not present{% endif %}</td>
+                <td>{% if diagnostic_logs_b %}Enabled{% else %}Not present{% endif %}</td>
+                <td class="col-status">
+                    {% if diagnostic_logs_differs %}<span class="badge badge-diff">Differs</span>{% else %}<span class="badge badge-same">Same</span>{% endif %}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</section>
+
+<section class="compare-section">
+    <h2>Action &amp; reusable workflow versions</h2>
+    <p class="hint">
+        GitHub Actions and reusable workflows used by each run. Each entry shows the
+        <code>owner/repo</code> (with an optional sub-path) and the tag, branch, or commit SHA
+        it was pinned to.
+    </p>
+    {% if action_pairs.is_empty() && action_only_in_a.is_empty() && action_only_in_b.is_empty() %}
+    <p class="hint">No action or reusable workflow references detected in either archive.</p>
+    {% else %}
+    {% if !action_pairs.is_empty() %}
+    <h3>Paired</h3>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr>
+                <th>Reference</th>
+                <th>Link</th>
+                <th>Side A</th>
+                <th>Side B</th>
+                <th class="col-status">Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in action_pairs %}
+            <tr class="{% if row.differs %}row-differs{% endif %}">
+                <td><code>{{ row.owner_repo_path }}</code></td>
+                <td><a href="{{ row.github_url }}" target="_blank" rel="noopener" class="action-link-icon" title="Open repository">🔗</a></td>
+                <td><code>{{ row.a_reference }}</code></td>
+                <td><code>{{ row.b_reference }}</code></td>
+                <td class="col-status">
+                    {% if row.differs %}<span class="badge badge-diff">Changed</span>{% else %}<span class="badge badge-same">Same</span>{% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if !action_only_in_a.is_empty() %}
+    <h3>Only in A</h3>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr><th>Reference</th><th>Link</th><th>Version/Ref</th></tr>
+        </thead>
+        <tbody>
+            {% for row in action_only_in_a %}
+            <tr><td><code>{{ row.owner_repo_path }}</code></td><td><a href="{{ row.github_url }}" target="_blank" rel="noopener" class="action-link-icon" title="Open repository">🔗</a></td><td><code>{{ row.reference }}</code></td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if !action_only_in_b.is_empty() %}
+    <h3>Only in B</h3>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr><th>Reference</th><th>Link</th><th>Version/Ref</th></tr>
+        </thead>
+        <tbody>
+            {% for row in action_only_in_b %}
+            <tr><td><code>{{ row.owner_repo_path }}</code></td><td><a href="{{ row.github_url }}" target="_blank" rel="noopener" class="action-link-icon" title="Open repository">🔗</a></td><td><code>{{ row.reference }}</code></td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+    {% endif %}
+</section>
+
+<section class="compare-section">
+    <h2>Step durations</h2>
+    <p class="hint">
+        How long each step took, measured from the first to the last timestamp in its log.
+        Δ is B minus A &mdash; a positive value means side B took longer than side A; a
+        negative value means side B was faster than side A; zero means the two durations matched.
+    </p>
+    {% if step_groups.is_empty() && steps_only_in_a.is_empty() && steps_only_in_b.is_empty() %}
+    <p class="hint">No step logs found in either archive.</p>
+    {% else %}
+    {% for group in step_groups %}
+    <h3>{{ group.job_folder }}</h3>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr>
+                <th>Step</th>
+                <th>Duration A</th>
+                <th>Duration B</th>
+                <th>Δ</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for s in group.steps %}
+            <tr>
+                <td>{{ s.label }}</td>
+                <td>{{ s.a_duration_display }}</td>
+                <td>{{ s.b_duration_display }}</td>
+                <td class="{{ s.delta_class }}">{{ s.delta_display }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endfor %}
+
+    {% if !steps_only_in_a.is_empty() %}
+    <h3>Only in A</h3>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr><th>Job folder</th><th>Step file</th><th>Duration</th></tr>
+        </thead>
+        <tbody>
+            {% for row in steps_only_in_a %}
+            <tr><td>{{ row.job_folder }}</td><td>{{ row.step_file }}</td><td>{{ row.duration_display }}</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if !steps_only_in_b.is_empty() %}
+    <h3>Only in B</h3>
+    <div class="compare-table-wrap">
+    <table class="compare-table">
+        <thead>
+            <tr><th>Job folder</th><th>Step file</th><th>Duration</th></tr>
+        </thead>
+        <tbody>
+            {% for row in steps_only_in_b %}
+            <tr><td>{{ row.job_folder }}</td><td>{{ row.step_file }}</td><td>{{ row.duration_display }}</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+    {% endif %}
+</section>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -30,6 +30,12 @@
 </section>
 {% endif %}
 
+<section class="compare-section">
+    <h2>Compare Two Analyses</h2>
+    <p class="hint">Diff runner versions, action references, step durations, and Azure regions across two uploaded log sets.</p>
+    <a href="/compare" class="btn btn-primary">Open comparison tool &rarr;</a>
+</section>
+
 <section class="cleanup-section">
     <h2>Manage Local Files</h2>
     <p class="hint">Storage path: <code>{{ upload_path }}</code></p>


### PR DESCRIPTION
## Add side-by-side compare view for two analyses

**What**
- New `/compare` page diffs two extracted log archives across runner type, runner identity (version, labels, self-hosted name/group/machine), runner image, Azure region, diagnostic-logs-enabled, action and reusable-workflow refs, and per-step durations.
- Optional fuzzy step matching pairs renumbered/reordered steps across reruns.
- Home page links to the new tool; pick two existing analyses, upload a fresh pair, or mix.

**Routes**
- `GET /compare` (form)
- `POST /compare/upload` (resolve/upload pair, then redirect)
- `GET /compare/{a_id}/{b_id}` (diff view, `?fuzzy=1` opt-in)

**Log parser fixes (also benefit the existing analysis view)**
- Strip leading UTF-8 BOM in workflow and runner logs.
- Skip `Job defined at:` lines and warning/error/notice prose when extracting action references; trim trailing punctuation. Eliminates false captures like `v4.` from deprecation warnings.

**Refactor**
- Extracted `sanitize_analysis_id`, `analysis_id_from_filename`, and `extract_uploaded_zip` from `routes::upload` so the compare upload path reuses the same validation and extraction.
- `home::list_analyses` is now `pub(crate)` to populate the compare form dropdowns.

**Templates / styles**
- New `compare.html` and `compare_result.html`.
- New `.btn` / `.btn-primary` styles plus a Compare view section in `style.css`.
- Bumped the `style.css` cache-buster.

**Docs**
- README updated: usage bullet, project structure, and routes table now describe the compare feature.

**Internal cleanup (unrelated to the feature, swept in)**
- `cargo fmt` over `tips.rs` and `settings.rs`.
- Collapsed nested `if let`s in `tips.rs` into a let chain; added two targeted `#[allow]` attributes on lints that were not worth a refactor.

**Verification**
- `cargo fmt --check` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test`: 80 passed, 0 failed (includes 4 new tests for the parser changes).

Closes: https://github.com/corycalahan/actions-recon/issues/29